### PR TITLE
feat: animated skill underlines in About (closes #39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Section folders may carry their own `contents.ts` (e.g. `hero-area/contents.ts` 
 - Cross-section/shared UI primitives live in `src/components/pages/common/` (e.g. `SectionHeading`, `Tag`). Section-specific subcomponents are colocated in the section folder next to its `contents.ts` (e.g. `projects-area/ProjectCard.tsx`, `projects-area/ProjectLink.tsx`, `skills-area/SkillGroup.tsx`).
 - Keep each section's `index.tsx` thin: section wrapper + `SectionHeading` + a `.map()` over a subcomponent. Data lives in `contents.ts`, not inline.
 - Reuse the shared `cn()` helper and existing primitives before creating new ones; avoid premature abstraction for genuinely one-off markup.
+- A component that spans more than one file (e.g. a co-located CSS Module, subcomponents, or its own `contents.ts`) gets its **own folder** with the entry point as `index.tsx` and its files beside it — e.g. `components/animations/AnimatedUnderline/index.tsx` + `AnimatedUnderline.module.css`. Keep genuinely single-file components as a single `.tsx`.
 
 ### Commit conventions
 

--- a/src/app/_root/about-me-area/index.tsx
+++ b/src/app/_root/about-me-area/index.tsx
@@ -1,3 +1,4 @@
+import AnimatedUnderline from '@/components/animations/AnimatedUnderline';
 import SectionHeading from '@/components/pages/common/SectionHeading';
 import {
     careerExperience,
@@ -37,34 +38,62 @@ export default function AboutMeArea() {
                             <strong>Full Stack Developer</strong> committed to
                             building scalable and maintainable web applications.
                             I specialize in{' '}
-                            <strong className="underline decoration-yellow-500">
+                            <AnimatedUnderline
+                                variant="draw-right"
+                                color="var(--color-yellow-500)"
+                                delayMs={0}
+                            >
                                 JavaScript
-                            </strong>
+                            </AnimatedUnderline>
                             ,{' '}
-                            <strong className="underline decoration-blue-500">
+                            <AnimatedUnderline
+                                variant="draw-left"
+                                color="var(--color-blue-500)"
+                                delayMs={120}
+                            >
                                 PHP
-                            </strong>
+                            </AnimatedUnderline>
                             , and{' '}
-                            <strong className="underline decoration-emerald-500">
+                            <AnimatedUnderline
+                                variant="center"
+                                color="var(--color-emerald-500)"
+                                delayMs={240}
+                            >
                                 Node.js
-                            </strong>
+                            </AnimatedUnderline>
                             , leveraging{' '}
-                            <strong className="underline decoration-indigo-500">
+                            <AnimatedUnderline
+                                variant="highlight"
+                                color="var(--color-indigo-500)"
+                                delayMs={360}
+                            >
                                 Docker
-                            </strong>{' '}
+                            </AnimatedUnderline>{' '}
                             for containerization and implementing{' '}
-                            <strong className="underline decoration-red-500">
+                            <AnimatedUnderline
+                                variant="rise"
+                                color="var(--color-red-500)"
+                                delayMs={480}
+                            >
                                 CI/CD
-                            </strong>{' '}
+                            </AnimatedUnderline>{' '}
                             pipelines to ensure efficient and reliable
                             deployments. I focus on{' '}
-                            <strong className="underline decoration-orange-500">
+                            <AnimatedUnderline
+                                variant="bounce"
+                                color="var(--color-orange-500)"
+                                delayMs={600}
+                            >
                                 clean code
-                            </strong>
+                            </AnimatedUnderline>
                             , robust{' '}
-                            <strong className="underline decoration-rose-500">
+                            <AnimatedUnderline
+                                variant="glow"
+                                color="var(--color-rose-500)"
+                                delayMs={720}
+                            >
                                 system design
-                            </strong>
+                            </AnimatedUnderline>
                             , and delivering solutions that create meaningful
                             impact.
                         </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,16 +23,6 @@
     --text-box-edge-text-alphabetic: text alphabetic;
     --text-box-edge-cap-alphabetic: cap alphabetic;
     --text-box-edge-ex-text: ex text;
-
-    --animate-shine: shine 5s linear infinite;
-    @keyframes shine {
-        0% {
-            background-position: 100%;
-        }
-        100% {
-            background-position: -100%;
-        }
-    }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/animations/AnimatedUnderline/AnimatedUnderline.module.css
+++ b/src/components/animations/AnimatedUnderline/AnimatedUnderline.module.css
@@ -1,0 +1,92 @@
+/* Animated skill underlines (issue #39).
+   Each variant draws a gradient underline in a unique way when scrolled into
+   view. Resting state is a full, visible underline, so with JS off or reduced
+   motion it degrades to a plain static underline.
+   Keyframes live in this module so CSS Modules can scope them alongside the
+   `animation` declarations that reference them. */
+
+.au {
+    --au-color: var(--au-c, currentColor);
+    background-image: linear-gradient(var(--au-color), var(--au-color));
+    background-repeat: no-repeat;
+    background-position: var(--au-pos, 0 100%);
+    background-size: var(--au-shown, 100% 0.1em);
+    padding-bottom: 0.06em;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+}
+
+/* per-variant geometry (direction / axis / shape) */
+.draw-right {
+    --au-pos: 0 100%;
+    --au-from: 0% 0.1em;
+    --au-shown: 100% 0.1em;
+}
+.draw-left {
+    --au-pos: 100% 100%;
+    --au-from: 0% 0.1em;
+    --au-shown: 100% 0.1em;
+}
+.center {
+    --au-pos: 50% 100%;
+    --au-from: 0% 0.1em;
+    --au-shown: 100% 0.1em;
+}
+.rise {
+    --au-pos: 0 100%;
+    --au-from: 100% 0%;
+    --au-shown: 100% 0.12em;
+}
+.bounce {
+    --au-pos: 0 100%;
+    --au-from: 0% 0.12em;
+    --au-shown: 100% 0.12em;
+    --au-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.glow {
+    --au-pos: 0 100%;
+    --au-from: 0% 0.1em;
+    --au-shown: 100% 0.1em;
+}
+.highlight {
+    --au-color: color-mix(in srgb, var(--au-c, currentColor) 26%, transparent);
+    --au-pos: 0 55%;
+    --au-from: 0% 1.05em;
+    --au-shown: 100% 1.05em;
+    border-radius: 0.15em;
+    padding-inline: 0.12em;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .au[data-au='idle'] {
+        background-size: var(--au-from);
+    }
+    .au[data-au='run'] {
+        animation: au-grow 0.6s var(--au-ease, ease-out) var(--au-delay, 0ms)
+            both;
+    }
+    .glow[data-au='run'] {
+        animation:
+            au-grow 0.6s ease-out var(--au-delay, 0ms) both,
+            au-glow 1.4s ease-in-out var(--au-delay, 0ms);
+    }
+}
+
+@keyframes au-grow {
+    from {
+        background-size: var(--au-from);
+    }
+    to {
+        background-size: var(--au-shown);
+    }
+}
+
+@keyframes au-glow {
+    0%,
+    100% {
+        filter: drop-shadow(0 0 0 transparent);
+    }
+    50% {
+        filter: drop-shadow(0 1px 6px var(--au-c, currentColor));
+    }
+}

--- a/src/components/animations/AnimatedUnderline/index.tsx
+++ b/src/components/animations/AnimatedUnderline/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/utils/cn';
+import styles from './AnimatedUnderline.module.css';
+
+export type UnderlineVariant =
+    | 'draw-right'
+    | 'draw-left'
+    | 'center'
+    | 'highlight'
+    | 'rise'
+    | 'bounce'
+    | 'glow';
+
+interface AnimatedUnderlineProps {
+    children: React.ReactNode;
+    /** Which unique underline animation to play. */
+    variant: UnderlineVariant;
+    /** Underline colour as a CSS value, e.g. `var(--color-yellow-500)`. */
+    color: string;
+    /** Stagger delay in milliseconds. */
+    delayMs?: number;
+}
+
+/**
+ * Highlights a keyword with an underline that animates in (uniquely per
+ * variant) once it scrolls into view. Falls back to a static underline when
+ * JavaScript is unavailable or the user prefers reduced motion.
+ */
+export default function AnimatedUnderline({
+    children,
+    variant,
+    color,
+    delayMs = 0,
+}: AnimatedUnderlineProps) {
+    const ref = useRef<HTMLElement>(null);
+    const [state, setState] = useState<'static' | 'idle' | 'run'>('static');
+
+    useEffect(() => {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            return; // keep the static, fully-drawn underline
+        }
+        const el = ref.current;
+        if (!el || !('IntersectionObserver' in window)) {
+            setState('run');
+            return;
+        }
+        setState('idle'); // collapse first (happens off-screen, no flash)
+        const observer = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) {
+                        setState('run');
+                        observer.disconnect();
+                        break;
+                    }
+                }
+            },
+            { threshold: 0.5 }
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    return (
+        <strong
+            ref={ref}
+            className={cn(styles.au, styles[variant])}
+            data-au={state === 'static' ? undefined : state}
+            style={
+                {
+                    '--au-c': color,
+                    '--au-delay': `${delayMs}ms`,
+                } as React.CSSProperties
+            }
+        >
+            {children}
+        </strong>
+    );
+}

--- a/src/components/animations/ShinyTextAnimation/ShinyTextAnimation.module.css
+++ b/src/components/animations/ShinyTextAnimation/ShinyTextAnimation.module.css
@@ -1,0 +1,17 @@
+/* Shiny shimmer for the hero name. The animation only runs when motion is
+   allowed (mirrors the previous `motion-safe:` behaviour); its duration is
+   overridden inline via the `speed` prop. */
+@media (prefers-reduced-motion: no-preference) {
+    .shine {
+        animation: shine 5s linear infinite;
+    }
+}
+
+@keyframes shine {
+    0% {
+        background-position: 100%;
+    }
+    100% {
+        background-position: -100%;
+    }
+}

--- a/src/components/animations/ShinyTextAnimation/index.tsx
+++ b/src/components/animations/ShinyTextAnimation/index.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/utils/cn';
 import React from 'react';
+import styles from './ShinyTextAnimation.module.css';
 
 interface ShinyTextAnimationProps {
     children: React.ReactNode;
@@ -20,7 +21,7 @@ const ShinyTextAnimation: React.FC<ShinyTextAnimationProps> = ({
         <div
             className={cn(
                 'inline-block bg-linear-120 from-black/70 from-40% via-black via-50% to-black/70 to-60% bg-clip-text not-supports-[text-box-trim:trim-both]:!text-[var(--foreground)] motion-safe:text-black/30 dark:from-white/30 dark:via-white dark:to-white/30 motion-safe:dark:text-white/70',
-                disabled ? '' : 'motion-safe:animate-shine',
+                disabled ? '' : styles.shine,
                 className
             )}
             style={{


### PR DESCRIPTION
Each highlighted keyword in the About bio now has a unique underline animation (draw-right, draw-left, expand-center, highlighter, rise, bounce, glow), staggered and triggered on scroll-in, with a static fallback for reduced motion / no JavaScript.

- New AnimatedUnderline component (IntersectionObserver) with a co-located CSS Module, in its own folder
- Move ShinyTextAnimation into its own folder + CSS Module; drop the shine keyframe from globals.css (now module-scoped)
- CLAUDE.md: document that multi-file components live in their own folder with an index.tsx entry