### PR TITLE
feat: add /uses and /now pages

### DIFF
--- a/src/app/now/BulletList.tsx
+++ b/src/app/now/BulletList.tsx
@@ -1,0 +1,9 @@
+export default function BulletList({ items }: { items: string[] }) {
+    return (
+        <ul className="marker:text-foreground/40 ml-5 flex max-w-3xl list-disc flex-col gap-2 text-2xl leading-normal">
+            {items.map((item) => (
+                <li key={item}>{item}</li>
+            ))}
+        </ul>
+    );
+}

--- a/src/app/now/NowBlock.tsx
+++ b/src/app/now/NowBlock.tsx
@@ -1,0 +1,38 @@
+import TagGroup from '@/components/pages/common/TagGroup';
+import type { NowBlockData } from './contents';
+import BulletList from './BulletList';
+
+export default function NowBlock({ block }: { block: NowBlockData }) {
+    switch (block.kind) {
+        case 'tags':
+            return <TagGroup tags={block.tags} />;
+        case 'list':
+            return <BulletList items={block.items} />;
+        case 'text':
+            return (
+                <p className="text-foreground/80 max-w-3xl text-2xl leading-normal">
+                    {block.text}
+                </p>
+            );
+        case 'subgroups':
+            return (
+                <div className="flex flex-col gap-8">
+                    {block.subgroups.map((subgroup) => (
+                        <div key={subgroup.title}>
+                            <h3 className="text-2xl font-semibold">
+                                {subgroup.title}
+                            </h3>
+                            {subgroup.intro && (
+                                <p className="text-foreground/70 mt-2 max-w-3xl text-xl leading-normal">
+                                    {subgroup.intro}
+                                </p>
+                            )}
+                            <div className="mt-4">
+                                <TagGroup tags={subgroup.tags} />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            );
+    }
+}

--- a/src/app/now/NowNav.tsx
+++ b/src/app/now/NowNav.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { nowNav } from './contents';
+
+export default function NowNav() {
+    return (
+        <nav className="border-foreground/15 mt-16 flex flex-wrap gap-x-8 gap-y-3 border-t pt-8 text-xl">
+            {nowNav.map((item) => (
+                <Link
+                    key={item.href}
+                    href={item.href}
+                    className="text-foreground/70 hover:text-foreground transition-colors"
+                >
+                    {item.direction === 'back'
+                        ? `← ${item.label}`
+                        : `${item.label} →`}
+                </Link>
+            ))}
+        </nav>
+    );
+}

--- a/src/app/now/NowSection.tsx
+++ b/src/app/now/NowSection.tsx
@@ -1,0 +1,39 @@
+import type { NowSectionData } from './contents';
+import NowBlock from './NowBlock';
+
+export default function NowSection({ section }: { section: NowSectionData }) {
+    return (
+        <section>
+            <h2 className="text-3xl font-bold sm:text-4xl">
+                <span
+                    aria-hidden="true"
+                    className="mr-3"
+                >
+                    {section.emoji}
+                </span>
+                {section.title}
+            </h2>
+
+            {section.intro && (
+                <p className="text-foreground/70 mt-3 max-w-3xl text-2xl leading-normal">
+                    {section.intro}
+                </p>
+            )}
+
+            <div className="mt-6 flex flex-col gap-6">
+                {section.blocks.map((block, index) => (
+                    <NowBlock
+                        key={`${block.kind}-${index}`}
+                        block={block}
+                    />
+                ))}
+            </div>
+
+            {section.outro && (
+                <p className="text-foreground/70 mt-6 max-w-3xl text-2xl leading-normal">
+                    {section.outro}
+                </p>
+            )}
+        </section>
+    );
+}

--- a/src/app/now/contents.ts
+++ b/src/app/now/contents.ts
@@ -1,0 +1,186 @@
+export type NowBlockData =
+    | { kind: 'tags'; tags: string[] }
+    | { kind: 'list'; items: string[] }
+    | { kind: 'text'; text: string }
+    | {
+          kind: 'subgroups';
+          subgroups: { title: string; intro?: string; tags: string[] }[];
+      };
+
+export type NowSectionData = {
+    title: string;
+    emoji: string;
+    intro?: string;
+    outro?: string;
+    blocks: NowBlockData[];
+};
+
+export const nowMeta = {
+    title: "What I'm Doing Now",
+    subtitle:
+        "A snapshot of what I'm currently building, learning, and focusing on.",
+    lastUpdated: 'June 2026',
+};
+
+export const nowSections: NowSectionData[] = [
+    {
+        title: 'Work',
+        emoji: '👨‍💻',
+        intro: 'Currently working as a Senior Software Engineer, building scalable web applications and backend systems. My daily work focuses on:',
+        blocks: [
+            {
+                kind: 'tags',
+                tags: [
+                    'Backend architecture',
+                    'API development',
+                    'Database optimization',
+                    'Performance improvements',
+                    'Code quality',
+                    'Solving challenging engineering problems',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Building',
+        emoji: '🤖',
+        intro: "These are the projects I'm actively working on.",
+        blocks: [
+            {
+                kind: 'subgroups',
+                subgroups: [
+                    {
+                        title: 'Personal Portfolio',
+                        intro: 'Building a modern portfolio with:',
+                        tags: [
+                            'Next.js',
+                            'TypeScript',
+                            'Tailwind CSS',
+                            'AI-powered "Ask Shibbir" assistant',
+                            'Interactive storytelling pages',
+                            'Developer blog',
+                        ],
+                    },
+                    {
+                        title: 'AI',
+                        intro: 'Exploring practical AI applications. Current interests:',
+                        tags: [
+                            'Large Language Models (LLMs)',
+                            'Agentic AI',
+                            'Retrieval-Augmented Generation (RAG)',
+                            'Model Context Protocol (MCP)',
+                            'Prompt Engineering',
+                            'Embeddings',
+                            'AI-assisted development',
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Learning',
+        emoji: '📚',
+        intro: "I'm currently investing time in becoming a stronger backend engineer. Topics I'm studying:",
+        blocks: [
+            {
+                kind: 'tags',
+                tags: [
+                    'System Design',
+                    'Distributed Systems',
+                    'PostgreSQL Performance',
+                    'Kubernetes',
+                    'Event-Driven Architecture',
+                    'Software Architecture',
+                    'Scalable Backend Systems',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Home Lab',
+        emoji: '🏠',
+        intro: "I'm constantly experimenting with my self-hosted infrastructure. Current playground:",
+        outro: 'I enjoy building infrastructure almost as much as building applications.',
+        blocks: [
+            {
+                kind: 'tags',
+                tags: [
+                    'Proxmox',
+                    'Docker',
+                    'LXC Containers',
+                    'Networking',
+                    'WireGuard',
+                    'Reverse Proxies',
+                    'Cloud Infrastructure',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Writing',
+        emoji: '📝',
+        intro: 'Working on documenting what I learn. Topics I want to write about:',
+        blocks: [
+            {
+                kind: 'tags',
+                tags: [
+                    'Backend Engineering',
+                    'AI Development',
+                    'Docker',
+                    'Home Lab',
+                    'Laravel',
+                    'Next.js',
+                    'System Design',
+                    'Lessons learned from real-world projects',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Reading',
+        emoji: '📖',
+        intro: 'Books currently on my reading list:',
+        blocks: [
+            {
+                kind: 'list',
+                items: [
+                    'Designing Data-Intensive Applications',
+                    'Clean Architecture',
+                    'System Design Interview',
+                    'Refactoring',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Goals',
+        emoji: '🎯',
+        intro: 'Current goals include:',
+        blocks: [
+            {
+                kind: 'list',
+                items: [
+                    'Become a world-class backend engineer',
+                    'Master system design',
+                    'Build production-ready AI applications',
+                    'Contribute more to open source',
+                    'Write consistently',
+                    'Keep learning every day',
+                ],
+            },
+        ],
+    },
+];
+
+export const nowQuote = 'The best engineers never stop learning.';
+
+export const nowNav: {
+    label: string;
+    href: string;
+    direction: 'back' | 'forward';
+}[] = [
+    { label: 'Uses', href: '/uses', direction: 'back' },
+    { label: 'Projects', href: '/#work', direction: 'forward' },
+    { label: 'Contact', href: '/#contact', direction: 'forward' },
+];

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next';
+import SectionHeading from '@/components/pages/common/SectionHeading';
+import NowSection from './NowSection';
+import NowNav from './NowNav';
+import { nowMeta, nowQuote, nowSections } from './contents';
+import { siteName } from '@/config/constants';
+
+const description = `What ${siteName} is focused on right now — current work, what he's building and learning, home-lab experiments, reading, and goals.`;
+
+export const metadata: Metadata = {
+    title: 'Now',
+    description,
+    alternates: { canonical: '/now' },
+    openGraph: {
+        title: `Now | ${siteName}`,
+        description,
+        url: '/now',
+        type: 'website',
+    },
+};
+
+export default function NowPage() {
+    return (
+        <main className="container mx-auto px-4 py-20 sm:py-28">
+            <SectionHeading as="h1">{nowMeta.title}</SectionHeading>
+            <p className="text-foreground/70 mt-6 max-w-3xl text-2xl leading-normal">
+                {nowMeta.subtitle}
+            </p>
+            <p className="text-foreground/60 mt-4 text-xl">
+                Last updated{' '}
+                <time className="text-foreground/80 font-semibold">
+                    {nowMeta.lastUpdated}
+                </time>
+            </p>
+
+            <div className="mt-12 flex flex-col gap-12 sm:gap-16">
+                {nowSections.map((section) => (
+                    <NowSection
+                        key={section.title}
+                        section={section}
+                    />
+                ))}
+            </div>
+
+            <blockquote className="text-foreground/80 mt-16 border-l-4 border-emerald-500 pl-6 text-3xl font-semibold italic">
+                {nowQuote}
+            </blockquote>
+
+            <NowNav />
+        </main>
+    );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,5 +12,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
             priority: 1,
             images: [`${siteURL}/images/shibbir-ahmed.jpg`],
         },
+        {
+            url: `${siteURL}/uses`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.7,
+        },
+        {
+            url: `${siteURL}/now`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.7,
+        },
     ];
 }

--- a/src/app/uses/GearList.tsx
+++ b/src/app/uses/GearList.tsx
@@ -1,0 +1,18 @@
+interface GearListProps {
+    gear: { name: string; description: string }[];
+}
+
+export default function GearList({ gear }: GearListProps) {
+    return (
+        <ul className="flex flex-col gap-5">
+            {gear.map((item) => (
+                <li key={item.name}>
+                    <h3 className="text-2xl font-semibold">{item.name}</h3>
+                    <p className="text-foreground/70 mt-1 max-w-3xl text-xl leading-normal">
+                        {item.description}
+                    </p>
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/src/app/uses/SpecList.tsx
+++ b/src/app/uses/SpecList.tsx
@@ -1,0 +1,34 @@
+import { Fragment } from 'react';
+import { cn } from '@/utils/cn';
+
+interface SpecListProps {
+    label?: string;
+    specs: { label: string; value: string }[];
+}
+
+export default function SpecList({ label, specs }: SpecListProps) {
+    return (
+        <div>
+            {label && (
+                <h3 className="text-foreground/60 text-xl font-bold">
+                    {label}
+                </h3>
+            )}
+            <dl
+                className={cn(
+                    'grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2',
+                    label && 'mt-3'
+                )}
+            >
+                {specs.map((spec) => (
+                    <Fragment key={spec.label}>
+                        <dt className="text-foreground/60 text-xl font-semibold">
+                            {spec.label}
+                        </dt>
+                        <dd className="text-xl">{spec.value}</dd>
+                    </Fragment>
+                ))}
+            </dl>
+        </div>
+    );
+}

--- a/src/app/uses/UsesBlock.tsx
+++ b/src/app/uses/UsesBlock.tsx
@@ -1,0 +1,31 @@
+import type { UsesBlockData } from './contents';
+import SpecList from './SpecList';
+import GearList from './GearList';
+import TagGroup from '@/components/pages/common/TagGroup';
+
+export default function UsesBlock({ block }: { block: UsesBlockData }) {
+    switch (block.kind) {
+        case 'specs':
+            return (
+                <SpecList
+                    label={block.label}
+                    specs={block.specs}
+                />
+            );
+        case 'tags':
+            return (
+                <TagGroup
+                    label={block.label}
+                    tags={block.tags}
+                />
+            );
+        case 'gear':
+            return <GearList gear={block.gear} />;
+        case 'text':
+            return (
+                <p className="text-foreground/70 max-w-3xl text-xl leading-normal">
+                    {block.text}
+                </p>
+            );
+    }
+}

--- a/src/app/uses/UsesSection.tsx
+++ b/src/app/uses/UsesSection.tsx
@@ -1,0 +1,33 @@
+import type { UsesSectionData } from './contents';
+import UsesBlock from './UsesBlock';
+
+export default function UsesSection({ section }: { section: UsesSectionData }) {
+    return (
+        <section>
+            <h2 className="text-3xl font-bold sm:text-4xl">
+                <span
+                    aria-hidden="true"
+                    className="mr-3"
+                >
+                    {section.emoji}
+                </span>
+                {section.title}
+            </h2>
+
+            {section.intro && (
+                <p className="text-foreground/70 mt-3 max-w-3xl text-2xl leading-normal">
+                    {section.intro}
+                </p>
+            )}
+
+            <div className="mt-6 flex flex-col gap-6">
+                {section.blocks.map((block, index) => (
+                    <UsesBlock
+                        key={`${block.kind}-${index}`}
+                        block={block}
+                    />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/app/uses/contents.ts
+++ b/src/app/uses/contents.ts
@@ -1,0 +1,318 @@
+export type UsesBlockData =
+    | {
+          kind: 'specs';
+          label?: string;
+          specs: { label: string; value: string }[];
+      }
+    | { kind: 'tags'; label?: string; tags: string[] }
+    | { kind: 'gear'; gear: { name: string; description: string }[] }
+    | { kind: 'text'; text: string };
+
+export type UsesSectionData = {
+    title: string;
+    emoji: string;
+    intro?: string;
+    blocks: UsesBlockData[];
+};
+
+export const usesSections: UsesSectionData[] = [
+    {
+        title: 'Development Workstation',
+        emoji: '💻',
+        intro: 'My primary machine for software development, AI experimentation, and gaming.',
+        blocks: [
+            {
+                kind: 'specs',
+                specs: [
+                    { label: 'CPU', value: 'AMD Ryzen 7 7700 (8C/16T)' },
+                    {
+                        label: 'GPU',
+                        value: 'ZOTAC GAMING GeForce RTX 5060 Ti 16GB Twin Edge',
+                    },
+                    {
+                        label: 'Memory',
+                        value: '32GB (2×16GB) Corsair VENGEANCE RGB DDR5 6000MHz',
+                    },
+                    {
+                        label: 'Storage',
+                        value: 'Lexar NM790 1TB PCIe Gen4 NVMe SSD',
+                    },
+                    {
+                        label: 'Motherboard',
+                        value: 'MSI B650M Gaming Plus WiFi',
+                    },
+                    {
+                        label: 'CPU Cooler',
+                        value: 'DeepCool ASSASSIN VC ELITE',
+                    },
+                    { label: 'Power Supply', value: 'Corsair CX750 750W' },
+                    { label: 'Case', value: 'Gamdias ATHENA M3 ARGB' },
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Displays',
+        emoji: '🖥️',
+        blocks: [
+            {
+                kind: 'specs',
+                specs: [
+                    {
+                        label: 'Primary',
+                        value: 'LG 24GN65R-B — 23.8" IPS, 144Hz',
+                    },
+                    {
+                        label: 'Secondary',
+                        value: 'Xiaomi Redmi 1A — 23.8" IPS, 100Hz',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Keyboards',
+        emoji: '⌨️',
+        blocks: [
+            {
+                kind: 'gear',
+                gear: [
+                    {
+                        name: 'Keychron K7',
+                        description:
+                            'My daily driver for work. I love the low-profile design, portability, and comfortable typing experience during long development sessions.',
+                    },
+                    {
+                        name: 'Royal Kludge R75',
+                        description:
+                            'My favorite compact mechanical keyboard when I want a traditional typing experience. The 75% layout, gasket mount, and hot-swappable switches make it enjoyable for both work and personal use.',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Mouse',
+        emoji: '🖱️',
+        blocks: [
+            {
+                kind: 'gear',
+                gear: [
+                    {
+                        name: 'Logitech MX Master 3S',
+                        description:
+                            "The best productivity mouse I've used. Excellent ergonomics, silent clicks, customizable buttons, and seamless multi-device support.",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Audio',
+        emoji: '🔊',
+        intro: 'Perfect for music while coding, online meetings, and watching technical talks.',
+        blocks: [
+            {
+                kind: 'tags',
+                tags: ['Edifier R1280DBs', 'Edifier T5 Subwoofer'],
+            },
+        ],
+    },
+    {
+        title: 'Home Lab',
+        emoji: '🏠',
+        intro: 'One of my favorite projects is my self-hosted home lab — where I experiment with infrastructure, networking, virtualization, automation, and self-hosting technologies.',
+        blocks: [
+            {
+                kind: 'specs',
+                label: 'Server',
+                specs: [
+                    { label: 'CPU', value: 'AMD Ryzen 7 5700G' },
+                    { label: 'Motherboard', value: 'MSI B450M-A PRO MAX II' },
+                    {
+                        label: 'Memory',
+                        value: '32GB Corsair Vengeance LPX DDR4',
+                    },
+                    { label: 'Storage', value: '512GB NVMe SSD' },
+                    { label: 'Cooler', value: 'DeepCool AG400' },
+                ],
+            },
+            { kind: 'tags', label: 'Hypervisor', tags: ['Proxmox VE'] },
+            {
+                kind: 'tags',
+                label: 'What I run',
+                tags: [
+                    'Docker',
+                    'LXC Containers',
+                    'Jellyfin',
+                    'Radarr',
+                    'Sonarr',
+                    'Prowlarr',
+                    'Bazarr',
+                    'qBittorrent',
+                    'SFTPGo',
+                    'Pi-hole',
+                    'Nginx Proxy Manager',
+                    'WireGuard',
+                    'WGDashboard',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Cloud Infrastructure',
+        emoji: '☁️',
+        intro: 'Alongside my home lab, I maintain a cloud server that hosts public-facing services and securely connects to my home network.',
+        blocks: [
+            {
+                kind: 'tags',
+                label: 'VPS',
+                tags: ['Hostinger VPS', 'Ubuntu Server'],
+            },
+            {
+                kind: 'tags',
+                label: 'Running',
+                tags: [
+                    'Docker',
+                    'Docker Compose',
+                    'WireGuard VPN',
+                    'Reverse Proxy',
+                    'Cloudflare Tunnel',
+                    'Personal APIs',
+                    'Development environments',
+                    'Self-hosted services',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Development',
+        emoji: '👨‍💻',
+        blocks: [
+            {
+                kind: 'tags',
+                label: 'Languages',
+                tags: [
+                    'PHP',
+                    'TypeScript',
+                    'JavaScript (ES6+)',
+                    'SQL',
+                    'Java',
+                    'Kotlin',
+                ],
+            },
+            {
+                kind: 'tags',
+                label: 'Frameworks',
+                tags: [
+                    'Laravel',
+                    'Next.js',
+                    'React',
+                    'Vue.js',
+                    'Nuxt.js',
+                    'Express.js',
+                ],
+            },
+            {
+                kind: 'tags',
+                label: 'Databases',
+                tags: [
+                    'PostgreSQL',
+                    'MySQL',
+                    'SQLite',
+                    'Firebase Firestore',
+                    'Redis',
+                    'Qdrant (Vector Database)',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'AI',
+        emoji: '🤖',
+        intro: 'AI has become part of my daily development workflow.',
+        blocks: [
+            {
+                kind: 'tags',
+                label: 'I use',
+                tags: ['ChatGPT', 'Claude Code', 'Google Gemini'],
+            },
+            {
+                kind: 'tags',
+                label: 'Mostly for',
+                tags: [
+                    'Architecture discussions',
+                    'Brainstorming',
+                    'Documentation',
+                    'Refactoring',
+                    'Code reviews',
+                    'Debugging',
+                    'Learning new technologies',
+                    'Rapid prototyping',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Infrastructure & DevOps',
+        emoji: '🐳',
+        blocks: [
+            {
+                kind: 'tags',
+                tags: [
+                    'Docker',
+                    'Docker Compose',
+                    'Linux',
+                    'Ubuntu Server',
+                    'Proxmox VE',
+                    'Cloudflare',
+                    'Nginx',
+                    'Caddy',
+                    'WireGuard',
+                    'Git',
+                    'GitHub',
+                    'SSH',
+                    'DNS Management',
+                    'Reverse Proxy',
+                    'SSL/TLS',
+                ],
+            },
+        ],
+    },
+    {
+        title: 'Developer Tools',
+        emoji: '🛠️',
+        blocks: [
+            {
+                kind: 'tags',
+                label: 'Editor',
+                tags: ['Visual Studio Code', 'Cursor'],
+            },
+            {
+                kind: 'tags',
+                label: 'API testing',
+                tags: ['Postman', 'Bruno', 'Requestly'],
+            },
+            {
+                kind: 'tags',
+                label: 'Package managers',
+                tags: ['npm', 'pnpm', 'Composer'],
+            },
+            {
+                kind: 'tags',
+                label: 'Version control',
+                tags: ['Git', 'GitHub', 'GitLab', 'Bitbucket'],
+            },
+            {
+                kind: 'tags',
+                label: 'Terminal',
+                tags: ['Windows Terminal', 'PowerShell', 'WSL'],
+            },
+            {
+                kind: 'tags',
+                label: 'Browser',
+                tags: ['Google Chrome', 'Firefox'],
+            },
+        ],
+    },
+];

--- a/src/app/uses/page.tsx
+++ b/src/app/uses/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+import SectionHeading from '@/components/pages/common/SectionHeading';
+import UsesSection from './UsesSection';
+import { usesSections } from './contents';
+import { siteName } from '@/config/constants';
+
+const description = `The gear, software, developer tools, and home-lab setup ${siteName} uses day to day for software development, AI, and self-hosting.`;
+
+export const metadata: Metadata = {
+    title: 'Uses',
+    description,
+    alternates: { canonical: '/uses' },
+    openGraph: {
+        title: `Uses | ${siteName}`,
+        description,
+        url: '/uses',
+        type: 'website',
+    },
+};
+
+export default function UsesPage() {
+    return (
+        <main className="container mx-auto px-4 py-20 sm:py-28">
+            <SectionHeading as="h1">Uses</SectionHeading>
+            <p className="text-foreground/70 mt-6 max-w-3xl text-2xl leading-normal">
+                The gear, software, and self-hosted setup I use day to day.
+            </p>
+
+            <div className="mt-12 flex flex-col gap-12 sm:gap-16">
+                {usesSections.map((section) => (
+                    <UsesSection
+                        key={section.title}
+                        section={section}
+                    />
+                ))}
+            </div>
+        </main>
+    );
+}

--- a/src/components/pages/common/SectionHeading.tsx
+++ b/src/components/pages/common/SectionHeading.tsx
@@ -3,16 +3,18 @@ import { HTMLAttributes } from 'react';
 
 interface SectionHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
     accentClassName?: string;
+    as?: 'h1' | 'h2' | 'h3';
 }
 
 export default function SectionHeading({
     children,
     className,
     accentClassName,
+    as: Heading = 'h2',
     ...rest
 }: SectionHeadingProps) {
     return (
-        <h2
+        <Heading
             className={cn('text-5xl font-bold sm:text-6xl', className)}
             {...rest}
         >
@@ -24,6 +26,6 @@ export default function SectionHeading({
             >
                 {children}
             </span>
-        </h2>
+        </Heading>
     );
 }

--- a/src/components/pages/common/TagGroup.tsx
+++ b/src/components/pages/common/TagGroup.tsx
@@ -1,0 +1,33 @@
+import Tag from '@/components/pages/common/Tag';
+import { cn } from '@/utils/cn';
+
+interface TagGroupProps {
+    label?: string;
+    tags: string[];
+}
+
+/**
+ * An optional sub-heading followed by a wrapped row of pill tags. Shared by the
+ * /uses and /now pages.
+ */
+export default function TagGroup({ label, tags }: TagGroupProps) {
+    return (
+        <div>
+            {label && (
+                <h3 className="text-foreground/60 text-xl font-bold">
+                    {label}
+                </h3>
+            )}
+            <ul className={cn('flex flex-wrap gap-3', label && 'mt-3')}>
+                {tags.map((tag) => (
+                    <Tag
+                        key={tag}
+                        className="hover:border-foreground/40 px-5 py-2 text-xl"
+                    >
+                        {tag}
+                    </Tag>
+                ))}
+            </ul>
+        </div>
+    );
+}


### PR DESCRIPTION
- /uses: hardware, displays, peripherals, home lab, cloud, dev stack, AI, infrastructure, and developer tools — data-driven via contents.ts
- /now: a Derek Sivers-style "now" page (work, building, learning, home lab, writing, reading, goals) with a last-updated date, a quote, and bottom navigation
- Add a shared TagGroup primitive used by both pages, give SectionHeading an optional `as` prop so pages get a proper <h1>, and list both routes in the sitemap