### PR TITLE
fix: scroll navbar logo to top reliably without a #hero hash

### DIFF
--- a/src/components/layout/Navbar/DesktopNav.tsx
+++ b/src/components/layout/Navbar/DesktopNav.tsx
@@ -1,7 +1,6 @@
-import Link from 'next/link';
-import Shibbir from '@/components/icons/shibbir';
 import { cn } from '@/utils/cn';
 import NavItem from './NavItem';
+import NavLogo from './NavLogo';
 import type { NavItemData } from './contents';
 
 interface DesktopNavProps {
@@ -29,13 +28,7 @@ export default function DesktopNav({
         >
             <ul className="border-foreground/10 bg-background/60 flex items-center gap-1 rounded-full border px-2 py-1.5 shadow-lg shadow-black/5 backdrop-blur-lg">
                 <li>
-                    <Link
-                        href="/#hero"
-                        aria-label="Home"
-                        className="text-foreground/80 hover:text-foreground block px-2 py-1.5 transition-colors"
-                    >
-                        <Shibbir className="h-5 w-auto" />
-                    </Link>
+                    <NavLogo className="text-foreground/80 hover:text-foreground block px-2 py-1.5 transition-colors" />
                 </li>
                 <li
                     aria-hidden="true"

--- a/src/components/layout/Navbar/MobileMenuPanel.tsx
+++ b/src/components/layout/Navbar/MobileMenuPanel.tsx
@@ -1,7 +1,6 @@
-import Link from 'next/link';
-import Shibbir from '@/components/icons/shibbir';
 import { cn } from '@/utils/cn';
 import NavItem from './NavItem';
+import NavLogo from './NavLogo';
 import type { NavItemData } from './contents';
 
 interface MobileMenuPanelProps {
@@ -29,14 +28,10 @@ export default function MobileMenuPanel({
                     : 'pointer-events-none invisible scale-95 opacity-0'
             )}
         >
-            <Link
-                href="/#hero"
-                aria-label="Home"
-                onClick={onNavigate}
+            <NavLogo
+                onNavigate={onNavigate}
                 className="text-foreground/80 hover:text-foreground hover:bg-foreground/5 flex items-center rounded-xl px-4 py-3 transition-colors"
-            >
-                <Shibbir className="h-5 w-auto" />
-            </Link>
+            />
             <div
                 aria-hidden="true"
                 className="bg-foreground/10 my-1 h-px"

--- a/src/components/layout/Navbar/NavLogo.tsx
+++ b/src/components/layout/Navbar/NavLogo.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { MouseEvent } from 'react';
+import Shibbir from '@/components/icons/shibbir';
+
+interface NavLogoProps {
+    className?: string;
+    onNavigate?: () => void;
+}
+
+/**
+ * Home logo. On the home page it smooth-scrolls back to the top and strips any
+ * hash from the URL, so the address bar stays at "/". On other pages it is a
+ * plain link home. We scroll in JS instead of linking to "#hero" because Next
+ * skips hash scrolling when the target is already partly in view, so a "#hero"
+ * link does nothing while the hero is still on screen.
+ */
+export default function NavLogo({ className, onNavigate }: NavLogoProps) {
+    const pathname = usePathname();
+
+    const scrollToTop = (event: MouseEvent<HTMLAnchorElement>) => {
+        onNavigate?.();
+        if (pathname !== '/') return;
+        event.preventDefault();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        window.history.replaceState(
+            window.history.state,
+            '',
+            window.location.pathname + window.location.search
+        );
+    };
+
+    return (
+        <Link
+            href="/"
+            aria-label="Home"
+            onClick={scrollToTop}
+            className={className}
+        >
+            <Shibbir className="h-5 w-auto" />
+        </Link>
+    );
+}


### PR DESCRIPTION
The logo linked to "/#hero", but Next's App Router skips hash scrolling when the target is already in view, so clicking it did nothing while the full-height hero was still partly on screen (it only worked after scrolling past the hero).

Add a reusable NavLogo that links home and, on the home page, smoothly scrolls to the top and strips any hash via history.replaceState so the URL stays "/". Wire it into DesktopNav and MobileMenuPanel and drop the now-unused Link/Shibbir imports.