### PR TITLE
feat: add footer to every page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,7 @@ import {
 import { GoogleTagManager } from '@next/third-parties/google';
 import { JsonLdScriptComponent } from '@/components/utils/JsonLdScriptComponent';
 import Navbar from '@/components/layout/Navbar';
+import Footer from '@/components/layout/Footer';
 import { hasArticles } from '@/lib/posts';
 
 const zainSansSerif = Zain({
@@ -131,7 +132,8 @@ export default function RootLayout({
                 className={`${zainSansSerif.variable} ${jetBrainsMono.variable} bg-background flex min-h-svh flex-col text-3xl antialiased`}
             >
                 <Navbar hasArticles={hasArticles()} />
-                {children}
+                <div className="flex grow flex-col">{children}</div>
+                <Footer />
             </body>
         </html>
     );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import AboutMeArea from './_root/about-me-area';
 import ArticlesArea from './_root/articles-area';
 import ContactArea from './_root/contact-area';
-import FooterArea from './_root/footer-area';
 import HeroArea from './_root/hero-area';
 import ProjectsArea from './_root/projects-area';
 import SkillsArea from './_root/skills-area';
@@ -20,8 +19,6 @@ export default function Home() {
             <ArticlesArea />
 
             <ContactArea />
-
-            <FooterArea />
         </main>
     );
 }

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -1,6 +1,6 @@
 import FooterBottom from '@/components/pages/common/FooterBottom';
 
-export default function FooterArea() {
+export default function Footer() {
     return (
         <footer className="flex flex-col pt-8">
             <div className="container mx-auto flex grow flex-col px-4">


### PR DESCRIPTION
Move the footer out of the home page into the shared root layout so it renders on every page (articles, article detail, now, uses), the same way the navbar does, instead of living only on the home page.

- Add a shared Footer component at components/layout/Footer, beside Navbar
- Render Footer in the root layout after the page content, wrapping children in a growing container so it stays at the bottom on short pages
- Remove the duplicate footer from the home page
- Delete the old home-only _root/footer-area folder

Closes #68