### PR TITLE
feat: hide hero scroll cue when the navbar appears

### DIFF
--- a/src/app/_root/hero-area/ScrollDownCue.tsx
+++ b/src/app/_root/hero-area/ScrollDownCue.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import DownIcon from '@/components/icons/down';
+import { heroId } from '@/components/layout/Navbar/contents';
+import { useNavbarVisibility } from '@/components/layout/Navbar/hooks/useNavbarVisibility';
+import { cn } from '@/utils/cn';
+
+/**
+ * Down-arrow scroll cue at the bottom of the hero. It is the inverse of the
+ * navbar and shares the same visibility signal: shown while the navbar is still
+ * hidden (user near the top of the page) and hidden once the navbar appears
+ * (hero scrolled ~halfway out of view).
+ */
+export default function ScrollDownCue() {
+    const navbarVisible = useNavbarVisibility(true, heroId);
+
+    return (
+        <a
+            href="#about"
+            aria-label="Scroll to the about section"
+            className={cn(
+                'text-foreground/40 hover:text-foreground/70 mb-6 transition-all duration-500 ease-out motion-reduce:transition-none motion-safe:animate-bounce sm:mb-10',
+                navbarVisible
+                    ? 'pointer-events-none invisible opacity-0'
+                    : 'visible opacity-100'
+            )}
+        >
+            <DownIcon
+                className="size-8"
+                aria-hidden="true"
+            />
+        </a>
+    );
+}

--- a/src/app/_root/hero-area/index.tsx
+++ b/src/app/_root/hero-area/index.tsx
@@ -1,5 +1,5 @@
 import ShinyTextAnimation from '@/components/animations/ShinyTextAnimation';
-import DownIcon from '@/components/icons/down';
+import ScrollDownCue from './ScrollDownCue';
 import SocialIcons from './SocialIcons';
 import WithGridAnimatedBackgroundWrapper from '@/components/wrappers/WithGridAnimatedBackgroundWrapper';
 import { professionalTitle } from '@/config/constants';
@@ -27,16 +27,7 @@ export default function HeroArea() {
                         </div>
                         <SocialIcons />
                     </div>
-                    <a
-                        href="#about"
-                        aria-label="Scroll to the about section"
-                        className="text-foreground/40 hover:text-foreground/70 mb-6 transition-colors motion-safe:animate-bounce sm:mb-10"
-                    >
-                        <DownIcon
-                            className="size-8"
-                            aria-hidden="true"
-                        />
-                    </a>
+                    <ScrollDownCue />
                 </div>
             </div>
         </WithGridAnimatedBackgroundWrapper>


### PR DESCRIPTION
Extract the hero down-arrow into a ScrollDownCue client component that reuses the navbar visibility hook. The cue is now the inverse of the navbar: shown while the navbar is hidden (top of page) and hidden once the navbar appears (hero scrolled ~halfway out of view).