### PR TITLE
fix: run eslint directly after next 16 dropped next lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,18 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+    {
+        // Build output and generated artifacts: never lint these.
+        // (Next 16 removed `next lint`, which used to scope this implicitly.)
+        ignores: [
+            '.next/**',
+            'out/**',
+            'build/**',
+            'next-env.d.ts',
+            '**/nextImageExportOptimizer/**',
+            '**/next-image-export-optimizer-hashes.json',
+        ],
+    },
     ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier'),
 ];
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev:https": "next dev --experimental-https",
         "build": "next build && next-image-export-optimizer",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "eslint"
     },
     "dependencies": {
         "@next/third-parties": "^15.3.3",


### PR DESCRIPTION
Next.js 16 removed the `next lint` command, so `pnpm lint` failed by parsing "lint" as a project directory. Point the script at the ESLint CLI (the repo already uses an ESLint 9 flat config) and add global ignores for build output (out/, .next/, build/, next-env.d.ts, image-optimizer artifacts) that next lint previously scoped implicitly.