### PR TITLE
feat: add code block headers with language, file path, and copy

### DIFF
--- a/content/articles/rag-pipeline-qdrant-gemini.md
+++ b/content/articles/rag-pipeline-qdrant-gemini.md
@@ -17,7 +17,7 @@ Retrieval-augmented generation (RAG) grounds a language model in your own data, 
 
 
 1. **Build the Docker Image**: Use the `Dockerfile` to build the Docker image for the Express application.
-   ```
+   ```sh
    docker build -t express-lb .
    ```
 
@@ -39,7 +39,7 @@ graph TD;
 
 Qdrant returns the nearest neighbours for a query embedding in milliseconds:
 
-```ts
+```ts src/lib/foo.ts
 const hits = await client.search('articles', {
     vector: queryEmbedding,
     limit: 5,

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -6,6 +6,7 @@ import ArticleCover from '@/components/pages/articles/ArticleCover';
 import ArticleGrid from '@/components/pages/articles/ArticleGrid';
 import TagLink from '@/components/pages/articles/TagLink';
 import MermaidRenderer from '@/components/pages/articles/MermaidRenderer';
+import CodeBlockCopy from '@/components/pages/articles/CodeBlock';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { buildArticleJsonLd } from '@/utils/articleJsonLd';
 import { formatDate } from '@/utils/formatDate';
@@ -103,6 +104,8 @@ export default async function ArticlePage({
                 <ArticleContent html={article.html} />
 
                 <MermaidRenderer />
+
+                <CodeBlockCopy />
 
                 <div className="mt-14">
                     <Link

--- a/src/components/pages/articles/ArticleContent/ArticleContent.module.css
+++ b/src/components/pages/articles/ArticleContent/ArticleContent.module.css
@@ -23,10 +23,8 @@
     color: var(--shiki-light);
 }
 .content pre:global(.shiki) {
-    margin: 1.6em 0;
+    margin: 0;
     padding: 1.1em 1.3em;
-    border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
-    border-radius: 0.75rem;
     overflow-x: auto;
     font-size: 0.9em;
     line-height: 1.6;
@@ -36,6 +34,47 @@
     font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
     font-weight: 400;
 }
+
+/* Code block wrapper: a header bar (language/extension badge + optional file
+   path + copy button) sits above the Shiki body. */
+.content :global(.code-block) {
+    margin: 1.6em 0;
+    border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background-color: var(--shiki-light-bg);
+}
+.content :global(.code-block__bar) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.4rem 0.5rem 0.4rem 0.9rem;
+    border-bottom: 1px solid
+        color-mix(in srgb, var(--foreground) 12%, transparent);
+}
+.content :global(.code-block__meta) {
+    display: flex;
+    min-width: 0;
+    align-items: baseline;
+    gap: 0.6rem;
+}
+.content :global(.code-block__lang) {
+    flex: none;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--foreground) 55%, transparent);
+}
+.content :global(.code-block__path) {
+    overflow: hidden;
+    font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+    font-size: 0.8rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: color-mix(in srgb, var(--foreground) 80%, transparent);
+}
 @media (prefers-color-scheme: dark) {
     .content :global(.shiki) {
         background-color: var(--shiki-dark-bg);
@@ -43,6 +82,9 @@
     .content :global(.shiki),
     .content :global(.shiki) span {
         color: var(--shiki-dark);
+    }
+    .content :global(.code-block) {
+        background-color: var(--shiki-dark-bg);
     }
 }
 

--- a/src/components/pages/articles/CodeBlock/CodeCopyButton.tsx
+++ b/src/components/pages/articles/CodeBlock/CodeCopyButton.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import CheckIcon from '@/components/icons/check';
+import CopyIcon from '@/components/icons/copy';
+import { useCopyToClipboard } from '@/components/pages/articles/hooks/useCopyToClipboard';
+
+/** Copy button shown in a code block's header; copies the block's source. */
+export default function CodeCopyButton({ code }: { code: string }) {
+    const [copied, copy] = useCopyToClipboard();
+    return (
+        <button
+            type="button"
+            aria-label={copied ? 'Copied' : 'Copy code'}
+            onClick={() => copy(code)}
+            className="text-foreground/55 hover:bg-foreground/10 hover:text-foreground focus-visible:bg-foreground/10 focus-visible:text-foreground inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors"
+        >
+            {copied ? (
+                <>
+                    <CheckIcon className="size-3.5 text-emerald-500" />
+                    Copied
+                </>
+            ) : (
+                <>
+                    <CopyIcon className="size-3.5" />
+                    Copy
+                </>
+            )}
+        </button>
+    );
+}

--- a/src/components/pages/articles/CodeBlock/hooks/useCodeCopySlots.ts
+++ b/src/components/pages/articles/CodeBlock/hooks/useCodeCopySlots.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface CodeCopySlot {
+    slot: HTMLElement;
+    code: string;
+    key: string;
+}
+
+/**
+ * Finds the copy-button slots that `posts.ts` emits in each code block header
+ * and reads that block's source from its `<pre><code>`, so a button can be
+ * portaled in.
+ */
+export function useCodeCopySlots(): CodeCopySlot[] {
+    const [slots, setSlots] = useState<CodeCopySlot[]>([]);
+
+    useEffect(() => {
+        const elements = Array.from(
+            document.querySelectorAll<HTMLElement>('[data-code-copy]')
+        );
+        if (elements.length === 0) return;
+
+        setSlots(
+            elements.map((slot, index) => {
+                const code =
+                    slot
+                        .closest('figure.code-block')
+                        ?.querySelector('pre code')?.textContent ?? '';
+                return { slot, code, key: `code-copy-${index}` };
+            })
+        );
+
+        return () => setSlots([]);
+    }, []);
+
+    return slots;
+}

--- a/src/components/pages/articles/CodeBlock/index.tsx
+++ b/src/components/pages/articles/CodeBlock/index.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import CodeCopyButton from '@/components/pages/articles/CodeBlock/CodeCopyButton';
+import { useCodeCopySlots } from '@/components/pages/articles/CodeBlock/hooks/useCodeCopySlots';
+
+/**
+ * Adds a copy button to every Shiki code block in the article body. The block
+ * header (language/extension + file path) is static HTML from `posts.ts`; here
+ * we portal a copy button into each header slot. Renders nothing itself.
+ */
+export default function CodeBlockCopy() {
+    const slots = useCodeCopySlots();
+    return (
+        <>
+            {slots.map(({ slot, code, key }) =>
+                createPortal(<CodeCopyButton code={code} />, slot, key)
+            )}
+        </>
+    );
+}

--- a/src/components/pages/articles/MermaidRenderer/MermaidCopyButton.tsx
+++ b/src/components/pages/articles/MermaidRenderer/MermaidCopyButton.tsx
@@ -3,7 +3,7 @@
 import CheckIcon from '@/components/icons/check';
 import CopyIcon from '@/components/icons/copy';
 import MermaidIconButton from '@/components/pages/articles/MermaidRenderer/MermaidIconButton';
-import { useCopyToClipboard } from '@/components/pages/articles/MermaidRenderer/hooks/useCopyToClipboard';
+import { useCopyToClipboard } from '@/components/pages/articles/hooks/useCopyToClipboard';
 import { cn } from '@/utils/cn';
 
 /**

--- a/src/components/pages/articles/hooks/useCopyToClipboard.ts
+++ b/src/components/pages/articles/hooks/useCopyToClipboard.ts
@@ -1,28 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-
-async function writeToClipboard(text: string): Promise<void> {
-    if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-        return;
-    }
-    // Fallback for non-secure contexts where the async Clipboard API is absent.
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.setAttribute('readonly', '');
-    textarea.style.position = 'fixed';
-    textarea.style.top = '-9999px';
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand('copy');
-    textarea.remove();
-}
+import { writeToClipboard } from '@/utils/clipboard';
 
 /**
  * Copies text to the clipboard and exposes a transient `copied` flag that flips
- * back to false after `resetDelayMs`, for showing a brief confirmation. Falls
- * back to a hidden textarea when the async Clipboard API is unavailable.
+ * back to false after `resetDelayMs`, for showing a brief confirmation. Shared
+ * by the Mermaid and code-block copy buttons.
  */
 export function useCopyToClipboard(
     resetDelayMs = 2000

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -172,9 +172,62 @@ const gistExtension: TokenizerAndRendererExtension = {
 type CodeToken = Tokens.Code & { highlighted?: string };
 const CODE_THEMES = { light: 'github-light', dark: 'github-dark' } as const;
 
-/** First word of a fenced block's info string (its language), defaulting to text. */
-function codeLang(token: CodeToken): string {
-    return (token.lang ?? '').trim().split(/\s+/)[0] || 'text';
+interface CodeMeta {
+    lang: string;
+    filePath?: string;
+}
+
+/**
+ * Parses a fenced block's info string into a language plus an optional file path
+ * (where the snippet belongs). Supports `lang path/to/file.ext` and
+ * `lang title="path/to/file.ext"`.
+ */
+function parseCodeMeta(token: CodeToken): CodeMeta {
+    const info = (token.lang ?? '').trim();
+    if (!info) return { lang: 'text' };
+    const [lang, ...rest] = info.split(/\s+/);
+    const titled = info.match(/title="([^"]+)"/);
+    const remainder = rest.join(' ').trim();
+    const filePath = titled
+        ? titled[1]
+        : remainder && !remainder.includes('=')
+          ? remainder
+          : undefined;
+    return { lang: lang || 'text', filePath };
+}
+
+/** Header label: the file extension when a path is given, else the language. */
+function codeLabel(lang: string, filePath?: string): string {
+    if (!filePath) return lang;
+    const name = filePath.split('/').pop() ?? filePath;
+    const dot = name.lastIndexOf('.');
+    return dot > 0 ? name.slice(dot + 1) : lang;
+}
+
+/**
+ * Wraps highlighted code in a header (language/extension badge + optional file
+ * path) with a copy-button slot the client fills in (see CodeBlock).
+ */
+function renderCodeBlock(
+    highlighted: string,
+    lang: string,
+    filePath?: string
+): string {
+    const pathHtml = filePath
+        ? `<span class="code-block__path">${escapeHtml(filePath)}</span>`
+        : '';
+    return (
+        `<figure class="code-block not-prose">` +
+        `<figcaption class="code-block__bar">` +
+        `<span class="code-block__meta">` +
+        `<span class="code-block__lang">${escapeHtml(codeLabel(lang, filePath))}</span>` +
+        pathHtml +
+        `</span>` +
+        `<span class="code-block__copy" data-code-copy></span>` +
+        `</figcaption>` +
+        highlighted +
+        `</figure>`
+    );
 }
 
 async function highlightCode(code: string, lang: string): Promise<string> {
@@ -199,13 +252,11 @@ marked.use({
     async walkTokens(token) {
         if (token.type === 'code') {
             const codeToken = token as CodeToken;
+            const { lang } = parseCodeMeta(codeToken);
             // Mermaid blocks render to SVG in the browser (see MermaidRenderer),
             // so skip Shiki and let the code renderer emit a <pre class="mermaid">.
-            if (codeLang(codeToken) === 'mermaid') return;
-            codeToken.highlighted = await highlightCode(
-                codeToken.text,
-                codeLang(codeToken)
-            );
+            if (lang === 'mermaid') return;
+            codeToken.highlighted = await highlightCode(codeToken.text, lang);
         }
         if (token.type === 'gist') {
             const gistToken = token as GistToken;
@@ -217,13 +268,16 @@ marked.use({
     renderer: {
         code(token) {
             const codeToken = token as CodeToken;
-            if (codeLang(codeToken) === 'mermaid') {
+            const { lang, filePath } = parseCodeMeta(codeToken);
+            if (lang === 'mermaid') {
                 return `<pre class="mermaid not-prose">${escapeHtml(
                     codeToken.text
                 )}</pre>`;
             }
-            if (codeToken.highlighted) return codeToken.highlighted;
-            return `<pre><code>${escapeHtml(codeToken.text)}</code></pre>`;
+            const highlighted =
+                codeToken.highlighted ??
+                `<pre><code>${escapeHtml(codeToken.text)}</code></pre>`;
+            return renderCodeBlock(highlighted, lang, filePath);
         },
     },
 });

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,19 @@
+/**
+ * Writes text to the clipboard, using the async Clipboard API where available
+ * and falling back to a hidden textarea for non-secure contexts.
+ */
+export async function writeToClipboard(text: string): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    textarea.remove();
+}


### PR DESCRIPTION
- Render a header on each Shiki code block: a language/extension badge plus an optional file path from the fence info string (```lang path/to/file.ext or title="..."), so tutorial readers know where a snippet belongs.
- Add a copy button to every code block, with a green check and Copied feedback; reads the block source from the DOM and is portaled into a static header slot.
- Extract clipboard handling into src/utils/clipboard and a shared useCopyToClipboard hook under articles/hooks; Mermaid copy now uses it too.
- Move the code-block frame to a wrapper so header + body read as one unit (dark mode included).
- Demo: label the shell block and add a file path in the RAG article.