### PR TITLE
fix: load JetBrains Mono only on single article pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Zain, JetBrains_Mono } from 'next/font/google';
+import { Zain } from 'next/font/google';
 import '@/app/globals.css';
 import {
     facebookPageId,
@@ -27,11 +27,6 @@ const zainSansSerif = Zain({
     variable: '--font-zain-sans-serif',
     subsets: ['latin'],
     weight: ['400', '700'],
-});
-
-const jetBrainsMono = JetBrains_Mono({
-    variable: '--font-jetbrains-mono',
-    subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
@@ -129,7 +124,7 @@ export default function RootLayout({
                 <GoogleTagManager gtmId={googleTagManagerId} />
             )}
             <body
-                className={`${zainSansSerif.variable} ${jetBrainsMono.variable} bg-background flex min-h-svh flex-col text-3xl antialiased`}
+                className={`${zainSansSerif.variable} bg-background flex min-h-svh flex-col text-3xl antialiased`}
             >
                 <Navbar hasArticles={hasArticles()} />
                 <div className="flex grow flex-col">{children}</div>

--- a/src/components/pages/articles/ArticleContent/index.tsx
+++ b/src/components/pages/articles/ArticleContent/index.tsx
@@ -1,5 +1,13 @@
+import { JetBrains_Mono } from 'next/font/google';
 import { cn } from '@/utils/cn';
 import styles from '@/components/pages/articles/ArticleContent/ArticleContent.module.css';
+
+// Colocated with the only consumer so the monospace font ships solely on the
+// single article page, instead of loading globally from the root layout.
+const jetBrainsMono = JetBrains_Mono({
+    variable: '--font-jetbrains-mono',
+    subsets: ['latin'],
+});
 
 /**
  * Renders an article's pre-built HTML (Markdown rendered with Shiki code
@@ -10,6 +18,7 @@ export default function ArticleContent({ html }: { html: string }) {
     return (
         <div
             className={cn(
+                jetBrainsMono.variable,
                 'prose prose-lg dark:prose-invert mt-10 max-w-none',
                 styles.content
             )}


### PR DESCRIPTION
The monospace font was loaded globally from the root layout, but its only consumer is ArticleContent (rendered on single article pages). Colocate the font loader with that component and scope its CSS variable to the article content subtree, so the font no longer ships on every page.

Closes #71