### PR TITLE
feat: add dynamic terminal-path breadcrumb to all non-home pages

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import Breadcrumb from '@/components/layout/Breadcrumb';
 import ArticleContent from '@/components/pages/articles/ArticleContent';
 import ArticleCover from '@/components/pages/articles/ArticleCover';
 import ArticleGrid from '@/components/pages/articles/ArticleGrid';
@@ -86,6 +87,7 @@ export default async function ArticlePage({
 
     return (
         <main className="container mx-auto px-4 py-20 sm:py-28">
+            <Breadcrumb currentName={article.title} />
             <article>
                 <div className="grid items-center gap-8 lg:grid-cols-2 lg:gap-12">
                     <ArticleCover

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Breadcrumb from '@/components/layout/Breadcrumb';
 import SectionHeading from '@/components/pages/common/SectionHeading';
 import NowSection from '@/components/pages/now/NowSection';
 import { nowMeta, nowQuote, nowSections } from '@/app/now/contents';
@@ -21,6 +22,7 @@ export const metadata: Metadata = {
 export default function NowPage() {
     return (
         <main className="container mx-auto px-4 py-20 sm:py-28">
+            <Breadcrumb />
             <SectionHeading as="h1">{nowMeta.title}</SectionHeading>
             <p className="text-foreground/70 mt-6 max-w-3xl text-2xl leading-normal">
                 {nowMeta.subtitle}

--- a/src/app/uses/page.tsx
+++ b/src/app/uses/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Breadcrumb from '@/components/layout/Breadcrumb';
 import SectionHeading from '@/components/pages/common/SectionHeading';
 import UsesSection from '@/components/pages/uses/UsesSection';
 import { usesSections } from '@/app/uses/contents';
@@ -21,6 +22,7 @@ export const metadata: Metadata = {
 export default function UsesPage() {
     return (
         <main className="container mx-auto px-4 py-20 sm:py-28">
+            <Breadcrumb />
             <SectionHeading as="h1">Uses</SectionHeading>
             <p className="text-foreground/70 mt-6 max-w-3xl text-2xl leading-normal">
                 The gear, software, and self-hosted setup I use day to day.

--- a/src/components/layout/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/layout/Breadcrumb/BreadcrumbItem.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { cn } from '@/utils/cn';
+import type { BreadcrumbItem as BreadcrumbItemData } from '@/components/layout/Breadcrumb/types';
+
+interface BreadcrumbItemProps {
+    item: BreadcrumbItemData;
+    /** The last crumb is the current page: rendered as plain, brighter text. */
+    isCurrent: boolean;
+}
+
+export default function BreadcrumbItem({ item, isCurrent }: BreadcrumbItemProps) {
+    if (isCurrent) {
+        return (
+            <span
+                aria-current="page"
+                className="text-foreground/90"
+            >
+                {item.label}
+            </span>
+        );
+    }
+
+    return (
+        <Link
+            href={item.href}
+            aria-label={item.name ?? item.label}
+            className={cn(
+                'hover:text-foreground transition-colors motion-reduce:transition-none'
+            )}
+        >
+            {item.label}
+        </Link>
+    );
+}

--- a/src/components/layout/Breadcrumb/index.tsx
+++ b/src/components/layout/Breadcrumb/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Fragment } from 'react';
+import { usePathname } from 'next/navigation';
+import { jetBrainsMono } from '@/config/fonts';
+import { cn } from '@/utils/cn';
+import { JsonLd } from '@/components/seo/JsonLd';
+import { buildBreadcrumbJsonLd } from '@/utils/breadcrumbJsonLd';
+import BreadcrumbItem from '@/components/layout/Breadcrumb/BreadcrumbItem';
+import type { BreadcrumbItem as BreadcrumbItemData } from '@/components/layout/Breadcrumb/types';
+
+/** Turn a URL segment into a human-readable name, e.g. `home-lab` -> `Home Lab`. */
+function toReadableName(segment: string): string {
+    return decodeURIComponent(segment)
+        .split('-')
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+}
+
+interface BreadcrumbProps {
+    /**
+     * Human-readable name for the current page in the JSON-LD, used when the URL
+     * slug alone is not descriptive (e.g. an article title). The visible crumb
+     * still shows the slug to keep the terminal-path look.
+     */
+    currentName?: string;
+}
+
+/**
+ * Terminal-path breadcrumb (e.g. `~ › articles › redis-caching-strategies`)
+ * shown on every page except home. It derives the trail from the current route,
+ * so new pages get a breadcrumb automatically with no per-page configuration.
+ * Rendered in JetBrains Mono with chevrons instead of slashes, and emits
+ * BreadcrumbList JSON-LD in production.
+ */
+export default function Breadcrumb({ currentName }: BreadcrumbProps) {
+    const pathname = usePathname();
+    const segments = pathname.split('/').filter(Boolean);
+
+    // Home (no path segments) intentionally has no breadcrumb.
+    if (segments.length === 0) return null;
+
+    const items: BreadcrumbItemData[] = [
+        { label: '~', href: '/', name: 'Home' },
+        ...segments.map((segment, index) => ({
+            label: decodeURIComponent(segment),
+            href: `/${segments.slice(0, index + 1).join('/')}`,
+            name: toReadableName(segment),
+        })),
+    ];
+
+    if (currentName) items[items.length - 1].name = currentName;
+
+    return (
+        <nav
+            aria-label="Breadcrumb"
+            className={cn(
+                jetBrainsMono.variable,
+                'text-foreground/60 mb-6 font-mono text-sm sm:text-base'
+            )}
+        >
+            <ol className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                {items.map((item, index) => (
+                    <Fragment key={item.href}>
+                        {index > 0 && (
+                            <li
+                                aria-hidden="true"
+                                className="text-foreground/30 select-none"
+                            >
+                                ›
+                            </li>
+                        )}
+                        <li>
+                            <BreadcrumbItem
+                                item={item}
+                                isCurrent={index === items.length - 1}
+                            />
+                        </li>
+                    </Fragment>
+                ))}
+            </ol>
+
+            {process.env.NODE_ENV === 'production' && (
+                <JsonLd data={buildBreadcrumbJsonLd(items)} />
+            )}
+        </nav>
+    );
+}

--- a/src/components/layout/Breadcrumb/types.ts
+++ b/src/components/layout/Breadcrumb/types.ts
@@ -1,0 +1,9 @@
+export interface BreadcrumbItem {
+    /** Mono display text for the segment, e.g. `~`, `articles`, the slug. */
+    label: string;
+    /** Route the segment points to. The final (current) item renders as plain
+     *  text, but still carries its href so the JSON-LD gets a full URL. */
+    href: string;
+    /** Human-readable name for the BreadcrumbList JSON-LD; falls back to label. */
+    name?: string;
+}

--- a/src/components/pages/articles/ArticleContent/index.tsx
+++ b/src/components/pages/articles/ArticleContent/index.tsx
@@ -1,13 +1,6 @@
-import { JetBrains_Mono } from 'next/font/google';
+import { jetBrainsMono } from '@/config/fonts';
 import { cn } from '@/utils/cn';
 import styles from '@/components/pages/articles/ArticleContent/ArticleContent.module.css';
-
-// Colocated with the only consumer so the monospace font ships solely on the
-// single article page, instead of loading globally from the root layout.
-const jetBrainsMono = JetBrains_Mono({
-    variable: '--font-jetbrains-mono',
-    subsets: ['latin'],
-});
 
 /**
  * Renders an article's pre-built HTML (Markdown rendered with Shiki code

--- a/src/components/pages/articles/ArticlesIndex.tsx
+++ b/src/components/pages/articles/ArticlesIndex.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import Breadcrumb from '@/components/layout/Breadcrumb';
 import SectionHeading from '@/components/pages/common/SectionHeading';
 import ArticleGrid from '@/components/pages/articles/ArticleGrid';
 import ArticlesList from '@/components/pages/articles/ArticlesList';
@@ -20,6 +21,7 @@ export default function ArticlesIndex({
 
     return (
         <main className="container mx-auto px-4 py-20 sm:py-28">
+            <Breadcrumb />
             <SectionHeading
                 as="h1"
                 accentClassName="decoration-emerald-500"

--- a/src/config/fonts.ts
+++ b/src/config/fonts.ts
@@ -1,0 +1,9 @@
+import { JetBrains_Mono } from 'next/font/google';
+
+// Shared so the monospace font is defined once and ships only on the pages that
+// opt in by applying `jetBrainsMono.variable` (the single article page and the
+// terminal-path breadcrumb), instead of loading globally from the root layout.
+export const jetBrainsMono = JetBrains_Mono({
+    variable: '--font-jetbrains-mono',
+    subsets: ['latin'],
+});

--- a/src/utils/breadcrumbJsonLd.ts
+++ b/src/utils/breadcrumbJsonLd.ts
@@ -1,0 +1,18 @@
+import { BreadcrumbList, WithContext } from 'schema-dts';
+import { siteURL } from '@/config/constants';
+import type { BreadcrumbItem } from '@/components/layout/Breadcrumb/types';
+
+export function buildBreadcrumbJsonLd(
+    items: BreadcrumbItem[]
+): WithContext<BreadcrumbList> {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: items.map((item, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: item.name ?? item.label,
+            item: `${siteURL}${item.href}`,
+        })),
+    };
+}


### PR DESCRIPTION
Adds a breadcrumb (e.g. `~ › articles › redis-caching-strategies`) on every page except home, rendered in JetBrains Mono with chevrons instead of slashes.

The trail is derived from the current route via usePathname(), so new pages get a correct breadcrumb automatically with no per-page data. Home excludes itself (no path segments). Also emits BreadcrumbList JSON-LD in production.

The JetBrains Mono definition moves to a shared src/config/fonts.ts so the font stays scoped to the breadcrumb and article pages instead of loading globally.

Closes #64