### PR TITLE
feat: add per-page gradient background on non-home pages (#75)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,64 @@ body {
     font-family: var(--font-noto-sans), Arial, Helvetica, sans-serif;
 }
 
+/* Registering the gradient colours as <color> custom properties lets them be
+   transitioned, so the wash cross-fades smoothly on navigation instead of
+   snapping to the next route's colours (a plain background-image cannot
+   transition, but a registered custom property used inside it can). */
+@property --page-grad-from {
+    syntax: '<color>';
+    inherits: false;
+    initial-value: transparent;
+}
+@property --page-grad-to {
+    syntax: '<color>';
+    inherits: false;
+    initial-value: transparent;
+}
+
+/* Per-page gradient background for every page except home (issue #75). The
+   element is a full-page wash rendered by PageGradientBackground on non-home
+   routes (absolutely positioned over the relative body, so it spans the whole
+   document and scrolls with the page rather than staying fixed). Its two accent
+   colours (--page-grad-from / --page-grad-to) are derived per route in
+   pageGradient.ts, so each page gets its own gradient and any new route is
+   assigned one automatically. Each accent colour is mixed a little into the base
+   background (a touch stronger in dark mode) rather than toward transparent, so
+   every stop stays on the base colour and the wash ends on the exact footer
+   background (var(--background)) at the bottom. That avoids the muddy "fade to
+   transparent" band and lets the gradient meet the footer seamlessly in both
+   light and dark mode. */
+.page-gradient {
+    background-image: linear-gradient(
+        180deg,
+        color-mix(in oklab, var(--page-grad-from) 6%, var(--background)) 0%,
+        color-mix(in oklab, var(--page-grad-to) 6%, var(--background)) 50%,
+        var(--background) 100%
+    );
+}
+
+@media (prefers-color-scheme: dark) {
+    .page-gradient {
+        background-image: linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--page-grad-from) 12%, var(--background)) 0%,
+            color-mix(in oklab, var(--page-grad-to) 12%, var(--background)) 50%,
+            var(--background) 100%
+        );
+    }
+}
+
+/* Cross-fade the wash on route change: the element persists across client
+   navigations, so transitioning its colour variables animates the gradient.
+   Honour reduced-motion preferences by leaving the change instant. */
+@media (prefers-reduced-motion: no-preference) {
+    .page-gradient {
+        transition:
+            --page-grad-from 700ms ease,
+            --page-grad-to 700ms ease;
+    }
+}
+
 /* Smooth gradient background for homepage content sections (issue #13).
    Each direct section of the homepage main swells from the base background
    to a faint wash of its own accent and back, so consecutive sections share

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,7 @@ import { GoogleTagManager } from '@next/third-parties/google';
 import { JsonLdScript } from '@/components/seo/JsonLdScript';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
+import PageGradientBackground from '@/components/backgrounds/PageGradientBackground';
 import { hasArticles } from '@/lib/posts';
 import { hasResume } from '@/lib/resume';
 import { notoSans } from '@/config/fonts';
@@ -119,8 +120,9 @@ export default function RootLayout({
                 <GoogleTagManager gtmId={googleTagManagerId} />
             )}
             <body
-                className={`${notoSans.variable} bg-background flex min-h-svh flex-col text-base antialiased`}
+                className={`${notoSans.variable} bg-background relative flex min-h-svh flex-col text-base antialiased`}
             >
+                <PageGradientBackground />
                 <Navbar
                     hasArticles={hasArticles()}
                     hasResume={hasResume()}

--- a/src/components/backgrounds/PageGradientBackground.tsx
+++ b/src/components/backgrounds/PageGradientBackground.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { usePathname } from 'next/navigation';
+import { pageGradientColors } from '@/utils/pageGradient';
+
+/**
+ * Full-page gradient wash shown on every page except the home page (which paints
+ * its own section swells). It is absolutely positioned over the relative body,
+ * so it spans the whole document and scrolls with the page. The accent colours
+ * are derived
+ * deterministically from the current route, so each page gets its own gradient
+ * and any new route is assigned one automatically. The actual gradient (and its
+ * light/dark tuning) lives in the `.page-gradient` rule in globals.css; here we
+ * only feed it the per-route colours via CSS variables.
+ *
+ * The element stays mounted on every route (transparent on home) rather than
+ * unmounting, so the registered colour properties transition on navigation and
+ * the wash cross-fades smoothly in/out and between pages (see globals.css).
+ */
+export default function PageGradientBackground() {
+    const pathname = usePathname();
+    const { from, to } =
+        pathname === '/'
+            ? { from: 'transparent', to: 'transparent' }
+            : pageGradientColors(pathname);
+
+    return (
+        <div
+            aria-hidden="true"
+            className="page-gradient pointer-events-none absolute inset-0 -z-10"
+            style={
+                {
+                    '--page-grad-from': from,
+                    '--page-grad-to': to,
+                } as CSSProperties
+            }
+        />
+    );
+}

--- a/src/utils/pageGradient.ts
+++ b/src/utils/pageGradient.ts
@@ -1,0 +1,28 @@
+import { hashString } from '@/utils/generateArticleCover';
+
+// Low saturation keeps every derived colour close to a neutral grey; the wash is
+// then mixed down to a very low opacity in CSS, so it sits just barely off the
+// light/dark background rather than reading as a colourful tint. Only the hue
+// really varies per page. Two hues spaced apart give a gentle two-tone shift.
+const SATURATION = 35;
+const LIGHTNESS = 52;
+
+/**
+ * Deterministically derives a two-colour gradient for a page from its route, so
+ * every non-home page gets its own "random" wash and any route added later is
+ * assigned one automatically (no manual config). Hues come straight from a hash
+ * of the route (reusing the article-cover hash), so the space is effectively
+ * continuous (360 hues) and distinct routes get distinct colours; the same route
+ * always yields the same pair, so builds are reproducible.
+ */
+export function pageGradientColors(seed: string): { from: string; to: string } {
+    const hash = hashString(seed);
+    const hueFrom = hash % 360;
+    // Offset the second hue by 120-200 degrees so the two colours read as a
+    // gradient rather than a single flat tint.
+    const hueTo = (hueFrom + 120 + ((hash >>> 8) % 80)) % 360;
+    return {
+        from: `hsl(${hueFrom} ${SATURATION}% ${LIGHTNESS}%)`,
+        to: `hsl(${hueTo} ${SATURATION}% ${LIGHTNESS}%)`,
+    };
+}


### PR DESCRIPTION
Every page except home gets its own subtle, full-page gradient wash. The two accent colours are derived deterministically from a hash of the route (reusing the article-cover hash), so each page has a distinct gradient and any new route is assigned one automatically with no config. The home page is excluded.

- PageGradientBackground (in the root layout) renders an absolutely positioned, full-page element that scrolls with the page; it reads the route via usePathname and feeds per-route colours as CSS variables, so the gradient is baked into the static HTML at build and is transparent on home.
- pageGradient.ts derives the two HSL hues from the route hash.
- The colours are mixed into the base background (var(--background)) at a very low opacity, stronger in dark mode, and the wash ends on the exact base background at the bottom, so it meets the footer seamlessly in both themes with no fade-to-transparent band.
- Registered as @property <color> custom properties with a 700ms transition (motion-safe), so the wash cross-fades smoothly when navigating between pages.