### PR TITLE
feat: add cursor-following spotlight on footer signature

### DIFF
--- a/src/components/layout/Footer/FooterBottom.tsx
+++ b/src/components/layout/Footer/FooterBottom.tsx
@@ -1,9 +1,9 @@
-import Shibbir from '@/components/icons/shibbir';
+import SignatureSpotlight from '@/components/layout/Footer/SignatureSpotlight';
 
 export default function FooterBottom() {
     return (
         <div>
-            <Shibbir className="text-neutral-300 dark:text-neutral-900" />
+            <SignatureSpotlight />
         </div>
     );
 }

--- a/src/components/layout/Footer/SignatureSpotlight/SignatureSpotlight.module.css
+++ b/src/components/layout/Footer/SignatureSpotlight/SignatureSpotlight.module.css
@@ -1,0 +1,54 @@
+/* Footer signature cursor spotlight: the glyphs change color only inside a soft
+   circle that follows the pointer, fading back to the dim watermark away from
+   it. The reveal layer is a brighter copy of the same SVG, masked to the circle,
+   so it only ever paints letters (never a visible disk or box edge). The pointer
+   vars are written by usePointerSpotlight; hover and reduced-motion are pure CSS,
+   so the pointer path never re-renders React. */
+
+.spotlight {
+    /* Size the spotlight from the signature's own width so the circle keeps the
+       same proportion at every breakpoint instead of swallowing a narrow logo.
+       container-type makes this element a size container, so 1cqw below is 1% of
+       its width; 72cqw matches the radius that looked right on desktop. */
+    container-type: inline-size;
+    --pointer-x: 50%;
+    --pointer-y: 50%;
+    --spotlight-radius: 72cqw;
+    --spotlight-edge: 80%;
+    --spotlight-color: #a3a3a3; /* neutral-400 (light): one step up from the neutral-300 base */
+}
+
+@media (prefers-color-scheme: dark) {
+    .spotlight {
+        --spotlight-color: #525252; /* neutral-600 (dark): one step up from the neutral-900 base */
+    }
+}
+
+.reveal {
+    color: var(--spotlight-color);
+    opacity: 0;
+    -webkit-mask-image: radial-gradient(
+        circle var(--spotlight-radius) at var(--pointer-x) var(--pointer-y),
+        #000 0%,
+        rgba(0, 0, 0, 0.5) 50%,
+        transparent var(--spotlight-edge)
+    );
+    mask-image: radial-gradient(
+        circle var(--spotlight-radius) at var(--pointer-x) var(--pointer-y),
+        #000 0%,
+        rgba(0, 0, 0, 0.5) 50%,
+        transparent var(--spotlight-edge)
+    );
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .spotlight:hover .reveal {
+        opacity: 0.3;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .reveal {
+        transition: opacity 220ms ease-out;
+    }
+}

--- a/src/components/layout/Footer/SignatureSpotlight/hooks/usePointerSpotlight.ts
+++ b/src/components/layout/Footer/SignatureSpotlight/hooks/usePointerSpotlight.ts
@@ -1,0 +1,42 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Tracks the pointer inside `containerRef` and writes its position to the
+ * --pointer-x / --pointer-y custom properties on that element, throttled to one
+ * write per animation frame. Writing straight to the DOM keeps the cursor path
+ * off React's render path. No-ops on coarse / hoverless pointers, so touch
+ * devices never attach a listener.
+ */
+export function usePointerSpotlight(
+    containerRef: RefObject<HTMLElement | null>
+) {
+    useEffect(() => {
+        const element = containerRef.current;
+        if (!element) return;
+        if (!window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+            return;
+        }
+
+        let frame = 0;
+        let clientX = 0;
+        let clientY = 0;
+
+        const onPointerMove = (event: PointerEvent) => {
+            clientX = event.clientX;
+            clientY = event.clientY;
+            if (frame) return;
+            frame = requestAnimationFrame(() => {
+                frame = 0;
+                const rect = element.getBoundingClientRect();
+                element.style.setProperty('--pointer-x', `${clientX - rect.left}px`);
+                element.style.setProperty('--pointer-y', `${clientY - rect.top}px`);
+            });
+        };
+
+        element.addEventListener('pointermove', onPointerMove);
+        return () => {
+            element.removeEventListener('pointermove', onPointerMove);
+            if (frame) cancelAnimationFrame(frame);
+        };
+    }, [containerRef]);
+}

--- a/src/components/layout/Footer/SignatureSpotlight/index.tsx
+++ b/src/components/layout/Footer/SignatureSpotlight/index.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useRef } from 'react';
+import { cn } from '@/utils/cn';
+import Shibbir from '@/components/icons/shibbir';
+import { usePointerSpotlight } from '@/components/layout/Footer/SignatureSpotlight/hooks/usePointerSpotlight';
+import styles from '@/components/layout/Footer/SignatureSpotlight/SignatureSpotlight.module.css';
+
+/**
+ * The footer signature whose glyphs change color only within a soft circle that
+ * follows the pointer, fading back to the dim watermark away from it. A brighter
+ * copy of the same SVG is masked to that circle and stacked over the dim base in
+ * one grid cell, so the two stay perfectly aligned at any width.
+ */
+export default function SignatureSpotlight() {
+    const containerRef = useRef<HTMLDivElement>(null);
+    usePointerSpotlight(containerRef);
+
+    return (
+        <div
+            ref={containerRef}
+            className={cn(styles.spotlight, 'relative isolate grid w-full')}
+        >
+            <Shibbir
+                aria-hidden
+                className="text-neutral-300 [grid-area:1/1] dark:text-neutral-900"
+            />
+            <Shibbir
+                aria-hidden
+                className={cn(styles.reveal, 'pointer-events-none [grid-area:1/1]')}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
Hovering the footer SHIBBIR AHMED signature now brightens its glyphs only within a soft circle that follows the pointer, fading back to the dim watermark away from it.

A second copy of the signature SVG is stacked over the dim base in one grid cell and masked with a radial-gradient centered on the cursor, so it only ever paints letters (no visible disk or box edge). The pointer position is written straight to CSS custom properties per animation frame, keeping the cursor path off React's render path. The effect is gated behind a fine, hovering pointer and respects prefers-reduced-motion, so touch devices see the static logo.

The circle radius is sized in cqw against the signature's own width (via container-type), so it holds the same proportion across breakpoints instead of a fixed pixel size swallowing narrow layouts.