### PR TITLE
feat: add glitch font swap on hero name (#12)

### DIFF
--- a/src/components/animations/GlitchFontSwap/GlitchFontSwap.module.css
+++ b/src/components/animations/GlitchFontSwap/GlitchFontSwap.module.css
@@ -1,0 +1,26 @@
+/* Hero name glitch font swap (issue #12).
+   This ONLY swaps the font-family, so the ShinyTextAnimation gradient shimmer on
+   the name is fully preserved (nothing recolours or repositions the text). Each
+   word carries the active face via .fontDisplay / .fontSans, and the hook
+   rapidly flickers the face during a brief glitch before settling on the next
+   face. Negative tracking on the wider Noto Sans keeps the flicker from
+   re-wrapping the name. Reduced motion keeps the static Zain name (the hook does
+   not run, so the face never leaves .fontDisplay).
+
+   These reference the next/font variables DIRECTLY (--font-zain-sans-serif /
+   --font-noto-sans), not the Tailwind theme tokens (--font-display /
+   --font-sans). The theme tokens are declared with `@theme inline` as
+   `--font-sans: var(--font-noto-sans)` on :root, but the next/font variable they
+   point at is only defined on the elements that apply next/font's `.variable`
+   class (the hero wrapper / body), not on :root, so the theme token resolves to
+   empty here and the font would silently fall back to the inherited Zain. The
+   underlying next/font variables are defined on this element's inherited chain,
+   so they resolve correctly. */
+
+.fontDisplay {
+    font-family: var(--font-zain-sans-serif);
+}
+.fontSans {
+    font-family: var(--font-noto-sans);
+    letter-spacing: -0.02em;
+}

--- a/src/components/animations/GlitchFontSwap/GlitchWord.tsx
+++ b/src/components/animations/GlitchFontSwap/GlitchWord.tsx
@@ -1,0 +1,23 @@
+interface GlitchWordProps {
+    children: string;
+    /** CSS Module class that sets the currently active font-family. */
+    fontClassName: string;
+}
+
+/**
+ * A single name word rendered in the currently active face. The real text stays
+ * in flow so it remains selectable and the accessible name, and the only thing
+ * that ever changes is its font-family (the shiny gradient is inherited from
+ * ShinyTextAnimation and untouched). The text-box-* utilities stay a plain
+ * string because routing them through cn()/tailwind-merge collapses the pair and
+ * drops the trim.
+ */
+export default function GlitchWord({ children, fontClassName }: GlitchWordProps) {
+    return (
+        <span
+            className={`${fontClassName} text-box-trim-trim-both text-box-edge-cap-alphabetic py-1`}
+        >
+            {children}
+        </span>
+    );
+}

--- a/src/components/animations/GlitchFontSwap/hooks/useGlitchFontSwap.ts
+++ b/src/components/animations/GlitchFontSwap/hooks/useGlitchFontSwap.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/** Quiet lead-in before the first glitch (the "after ~10s" from issue #12). */
+export const INITIAL_DELAY_MS = 10_000;
+/** Start-to-start spacing between glitches: hold a face, then glitch to the next. */
+export const CYCLE_INTERVAL_MS = 10_000;
+/** When the flicker settles on (and holds) the cycle's target face. */
+export const GLITCH_SETTLE_MS = 360;
+
+export type FontPhase = 'display' | 'sans';
+
+/**
+ * The faces each glitch settles on and HOLDS until the next glitch, in order:
+ * Zain -> Noto Sans -> Zain ... so the font visibly changes and stays changed,
+ * and the name periodically returns to the original Zain. Both faces are already
+ * loaded on the home route (Zain is the hero display font, Noto Sans is the
+ * global body font), so this ships no extra font bytes. JetBrains Mono is
+ * deliberately not used here so the monospace font keeps loading only on the
+ * pages that opt into it (the breadcrumb and article detail page).
+ */
+const TARGET_FONTS: FontPhase[] = ['sans', 'display'];
+
+/**
+ * The rapid stutter played before the face settles, read as a digital glitch.
+ * Each entry is the face to flash and its offset in ms from the glitch start.
+ */
+const FLICKER_FRAMES: { font: FontPhase; at: number }[] = [
+    { font: 'sans', at: 0 },
+    { font: 'display', at: 90 },
+    { font: 'sans', at: 160 },
+    { font: 'display', at: 230 },
+    { font: 'sans', at: 300 },
+];
+
+interface GlitchController {
+    fontPhase: FontPhase;
+}
+
+/**
+ * Drives the hero name's recurring font glitch. Stays on the display font (Zain)
+ * on the server and on the first client render (so hydration matches). Only when
+ * motion is allowed it waits INITIAL_DELAY_MS, then every CYCLE_INTERVAL_MS
+ * plays a brief flicker and settles on the next target face, holding it until
+ * the next glitch. Only the font-family changes, so the ShinyTextAnimation
+ * shimmer is preserved throughout. Reduced motion keeps it static forever,
+ * mirroring AnimatedUnderline's static fallback.
+ */
+export function useGlitchFontSwap(): GlitchController {
+    const [fontPhase, setFontPhase] = useState<FontPhase>('display');
+
+    useEffect(() => {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            return; // keep the static Zain shiny name: no font glitch
+        }
+
+        // Which face the next glitch settles on. A plain counter in the effect
+        // scope (not React state) so advancing it never triggers a render.
+        let targetIndex = 0;
+
+        // Timers for the glitch currently playing. Reset each glitch so they do
+        // not accumulate; the previous glitch's timers have already fired by the
+        // time the next one starts (the flicker is far shorter than the interval).
+        const flickerTimers: ReturnType<typeof setTimeout>[] = [];
+
+        const playGlitch = () => {
+            flickerTimers.forEach(clearTimeout);
+            flickerTimers.length = 0;
+            const target = TARGET_FONTS[targetIndex % TARGET_FONTS.length];
+            targetIndex += 1;
+            for (const frame of FLICKER_FRAMES) {
+                flickerTimers.push(
+                    setTimeout(() => setFontPhase(frame.font), frame.at)
+                );
+            }
+            flickerTimers.push(
+                setTimeout(() => setFontPhase(target), GLITCH_SETTLE_MS)
+            );
+        };
+
+        let intervalId: ReturnType<typeof setInterval>;
+        const startId = setTimeout(() => {
+            playGlitch();
+            intervalId = setInterval(playGlitch, CYCLE_INTERVAL_MS);
+        }, INITIAL_DELAY_MS);
+
+        return () => {
+            clearTimeout(startId);
+            clearInterval(intervalId);
+            flickerTimers.forEach(clearTimeout);
+        };
+    }, []);
+
+    return { fontPhase };
+}

--- a/src/components/animations/GlitchFontSwap/index.tsx
+++ b/src/components/animations/GlitchFontSwap/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import GlitchWord from '@/components/animations/GlitchFontSwap/GlitchWord';
+import {
+    useGlitchFontSwap,
+    type FontPhase,
+} from '@/components/animations/GlitchFontSwap/hooks/useGlitchFontSwap';
+import styles from '@/components/animations/GlitchFontSwap/GlitchFontSwap.module.css';
+
+/** Maps the active font phase to the CSS Module class that applies its face. */
+const fontClassName: Record<FontPhase, string> = {
+    display: styles.fontDisplay,
+    sans: styles.fontSans,
+};
+
+interface GlitchFontSwapProps {
+    /** The name words, each rendered as a separate, selectable, readable span. */
+    words: string[];
+}
+
+/**
+ * Renders the hero name words and, once mounted (and only when motion is
+ * allowed), periodically plays a brief glitch that flickers the name's font and
+ * settles on the next face, holding it until the next glitch (Zain -> Noto Sans
+ * -> Zain). Only the font-family changes, so the existing shiny gradient is
+ * preserved. The words are returned as a fragment so they stay direct flex
+ * children of the hero h1, leaving its flex-wrap layout intact. Under reduced
+ * motion the name stays static in the display font (Zain).
+ */
+export default function GlitchFontSwap({ words }: GlitchFontSwapProps) {
+    const { fontPhase } = useGlitchFontSwap();
+
+    return (
+        <>
+            {words.map((word) => (
+                <GlitchWord key={word} fontClassName={fontClassName[fontPhase]}>
+                    {word}
+                </GlitchWord>
+            ))}
+        </>
+    );
+}

--- a/src/components/layout/Breadcrumb/index.tsx
+++ b/src/components/layout/Breadcrumb/index.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment } from 'react';
 import { usePathname } from 'next/navigation';
-import { jetBrainsMono } from '@/config/fonts';
+import { jetBrainsMono } from '@/config/monoFont';
 import { cn } from '@/utils/cn';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { buildBreadcrumbJsonLd } from '@/utils/breadcrumbJsonLd';

--- a/src/components/pages/articles/ArticleContent/index.tsx
+++ b/src/components/pages/articles/ArticleContent/index.tsx
@@ -1,4 +1,4 @@
-import { jetBrainsMono } from '@/config/fonts';
+import { jetBrainsMono } from '@/config/monoFont';
 import { cn } from '@/utils/cn';
 import styles from '@/components/pages/articles/ArticleContent/ArticleContent.module.css';
 

--- a/src/components/pages/home/HeroArea/index.tsx
+++ b/src/components/pages/home/HeroArea/index.tsx
@@ -1,8 +1,13 @@
+import GlitchFontSwap from '@/components/animations/GlitchFontSwap';
 import ShinyTextAnimation from '@/components/animations/ShinyTextAnimation';
 import ScrollDownCue from '@/components/pages/home/HeroArea/ScrollDownCue';
 import SocialIcons from '@/components/pages/home/HeroArea/SocialIcons';
 import WithGridAnimatedBackgroundWrapper from '@/components/wrappers/WithGridAnimatedBackgroundWrapper';
-import { professionalTitle } from '@/config/constants';
+import {
+    personFamilyName,
+    personGivenName,
+    professionalTitle,
+} from '@/config/constants';
 import { zain } from '@/config/fonts';
 import { cn } from '@/utils/cn';
 
@@ -15,12 +20,12 @@ export default function HeroArea() {
                         <div className="flex flex-col gap-y-2 px-4 sm:gap-y-3 md:gap-y-4 lg:items-end lg:justify-center">
                             <ShinyTextAnimation>
                                 <h1 className="flex flex-wrap items-center justify-center gap-x-8 text-[length:clamp(2.75rem,14vw,6rem)] leading-none font-bold sm:text-8xl sm:leading-10 md:gap-x-12 md:text-9xl md:leading-12">
-                                    <span className="text-box-trim-trim-both text-box-edge-cap-alphabetic py-1">
-                                        Shibbir
-                                    </span>
-                                    <span className="text-box-trim-trim-both text-box-edge-cap-alphabetic py-1">
-                                        Ahmed
-                                    </span>
+                                    <GlitchFontSwap
+                                        words={[
+                                            personGivenName,
+                                            personFamilyName,
+                                        ]}
+                                    />
                                 </h1>
                             </ShinyTextAnimation>
                             <p className="self-center text-center text-2xl leading-tight sm:leading-5 lg:self-end lg:pr-[5px]">

--- a/src/config/fonts.ts
+++ b/src/config/fonts.ts
@@ -1,4 +1,4 @@
-import { JetBrains_Mono, Noto_Sans, Zain } from 'next/font/google';
+import { Noto_Sans, Zain } from 'next/font/google';
 
 // Noto Sans is the site's default body font (applied globally in the root
 // layout). It is a neutral, standard-proportioned sans, so type sizes read at
@@ -17,10 +17,6 @@ export const zain = Zain({
     weight: ['400', '700'],
 });
 
-// Shared so the monospace font is defined once and ships only on the pages that
-// opt in by applying `jetBrainsMono.variable` (the single article page and the
-// terminal-path breadcrumb), instead of loading globally from the root layout.
-export const jetBrainsMono = JetBrains_Mono({
-    variable: '--font-jetbrains-mono',
-    subsets: ['latin'],
-});
+// JetBrains Mono is intentionally NOT defined here. It lives in its own module
+// (@/config/monoFont) so importing this file from the root layout and the home
+// hero does not pull the monospace font onto every route. See that file for why.

--- a/src/config/monoFont.ts
+++ b/src/config/monoFont.ts
@@ -1,0 +1,13 @@
+import { JetBrains_Mono } from 'next/font/google';
+
+// JetBrains Mono lives in its OWN module, separate from fonts.ts, so it ships
+// only on the pages that import it (the terminal-path breadcrumb and the article
+// detail page). next/font preloads every font co-instantiated in an imported
+// module, and fonts.ts is pulled into every route through the root layout
+// (notoSans) and the home hero (zain). Keeping the monospace font out of fonts.ts
+// is what actually keeps it off the home page and other routes that do not opt
+// in by applying `jetBrainsMono.variable`.
+export const jetBrainsMono = JetBrains_Mono({
+    variable: '--font-jetbrains-mono',
+    subsets: ['latin'],
+});


### PR DESCRIPTION
After ~10s the hero name plays a brief font-only glitch that flickers and settles on the next face, holding it before glitching again (Zain -> Noto Sans -> Zain). Only the font-family changes, so the existing shiny gradient is preserved; reduced motion keeps the static Zain name and SSR renders Zain.

The swap references the next/font variables directly (--font-zain-sans-serif, --font-noto-sans) rather than the @theme inline tokens (--font-display, --font-sans), which resolve to empty off the elements that define them and would silently fall back to Zain.

Move JetBrains Mono into its own module (config/monoFont) so it is no longer co-instantiated in fonts.ts and preloaded on every route; it now loads only on the breadcrumb and article detail pages that opt in.