### PR TITLE
chore: remove "Back to all articles" link from article page

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import Breadcrumb from '@/components/layout/Breadcrumb';
 import ArticleContent from '@/components/pages/articles/ArticleContent';
@@ -104,15 +103,6 @@ export default async function ArticlePage({
                 <MermaidRenderer />
 
                 <CodeBlockCopy />
-
-                <div className="mt-14">
-                    <Link
-                        href="/articles"
-                        className="text-foreground/70 hover:text-foreground text-sm transition-colors"
-                    >
-                        Back to all articles
-                    </Link>
-                </div>
             </article>
 
             {related.length > 0 && (


### PR DESCRIPTION
The breadcrumb already provides navigation back to the list, so the trailing link was redundant. Also drops the now-unused next/link import.