### PR TITLE
feat: soft hover glow on article cards matched to their cover

### DIFF
--- a/src/components/pages/articles/ArticleCard/ArticleCard.module.css
+++ b/src/components/pages/articles/ArticleCard/ArticleCard.module.css
@@ -1,0 +1,45 @@
+@reference "tailwindcss";
+
+/* Soft, top-to-bottom glow revealed on article-card hover (#articles / #work),
+   coloured to match the card's cover thumbnail. A ::before layer behind the card
+   content (the card is `relative isolate`, so z-index keeps it under the image and
+   text) holds a vertical gradient built from the cover's two colours (--cover-from
+   / --cover-to, set inline per card) fading out downward. It glows in slowly on
+   hover via a long opacity transition. Deliberately very soft, and softer still in
+   dark mode. @apply covers the utility-mappable rules; the gradient is raw CSS. */
+.card {
+    --tint-strength: 8%;
+}
+
+@media (prefers-color-scheme: dark) {
+    .card {
+        /* A translucent colour over near-black reads much dimmer than over the
+           light background, so dark mode needs a higher mix to stay visible
+           while still feeling soft. */
+        --tint-strength: 14%;
+    }
+}
+
+.card::before {
+    @apply pointer-events-none absolute inset-0 z-[-1] opacity-0 content-[''] motion-safe:transition-opacity motion-safe:duration-700;
+    background-image: linear-gradient(
+        to bottom,
+        color-mix(
+                in oklab,
+                var(--cover-from, var(--foreground)) var(--tint-strength),
+                transparent
+            )
+            0%,
+        color-mix(
+                in oklab,
+                var(--cover-to, var(--foreground)) var(--tint-strength),
+                transparent
+            )
+            50%,
+        transparent 92%
+    );
+}
+
+.card:hover::before {
+    @apply opacity-100;
+}

--- a/src/components/pages/articles/ArticleCard/index.tsx
+++ b/src/components/pages/articles/ArticleCard/index.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
 import ArticleCover from '@/components/pages/articles/ArticleCover';
+import styles from '@/components/pages/articles/ArticleCard/ArticleCard.module.css';
 import TagLink from '@/components/pages/articles/TagLink';
 import { cn } from '@/utils/cn';
 import { formatDate } from '@/utils/formatDate';
 import type { ArticleSummary } from '@/lib/posts';
+import type { CSSProperties } from 'react';
 
 export default function ArticleCard({
     article,
@@ -12,8 +14,21 @@ export default function ArticleCard({
     article: ArticleSummary;
     compact?: boolean;
 }) {
+    // Tint the card to match its cover thumbnail; the glow itself fades in on
+    // hover (see ArticleCard.module.css).
+    const coverColors = {
+        '--cover-from': article.coverColors[0],
+        '--cover-to': article.coverColors[1],
+    } as CSSProperties;
+
     return (
-        <li className="border-foreground/10 hover:border-foreground/30 relative flex h-full flex-col overflow-hidden rounded-2xl border transition-all duration-300 hover:shadow-lg">
+        <li
+            style={coverColors}
+            className={cn(
+                styles.card,
+                'border-foreground/10 hover:border-foreground/30 relative isolate flex h-full flex-col overflow-hidden rounded-2xl border transition-all duration-300 hover:shadow-lg'
+            )}
+        >
             <ArticleCover
                 src={article.cover}
                 className="aspect-video"
@@ -45,7 +60,9 @@ export default function ArticleCard({
                     <h3
                         className={cn(
                             'mt-2 font-bold',
-                            compact ? 'text-base sm:text-lg' : 'text-lg sm:text-xl'
+                            compact
+                                ? 'text-base sm:text-lg'
+                                : 'text-lg sm:text-xl'
                         )}
                     >
                         {article.title}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -7,9 +7,13 @@ import {
     type TokenizerAndRendererExtension,
 } from 'marked';
 import { codeToHtml } from 'shiki';
-import { generatedCoverPath } from '@/utils/generateArticleCover';
+import {
+    coverGradientForSlug,
+    generatedCoverPath,
+} from '@/utils/generateArticleCover';
 
 const ARTICLES_DIRECTORY = path.join(process.cwd(), 'content/articles');
+const PUBLIC_DIRECTORY = path.join(process.cwd(), 'public');
 
 /** How many articles are listed per page on the /articles index. */
 export const ARTICLES_PER_PAGE = 9;
@@ -32,6 +36,8 @@ export interface ArticleSummary {
     updated?: string;
     tags: string[];
     cover: string;
+    /** The cover's two dominant colours, used to tint the card to match it. */
+    coverColors: readonly [string, string];
     readingMinutes: number;
 }
 
@@ -69,8 +75,34 @@ function estimateReadingMinutes(content: string): number {
     return Math.max(1, Math.round(words / 200));
 }
 
+/**
+ * The two dominant colours of an article's cover, so the card can tint itself to
+ * match its thumbnail. Generated covers reuse the same gradient pair the SVG is
+ * built from; author-provided covers are read from disk and their first two
+ * gradient stops parsed. Falls back to the deterministic pair if the file is
+ * missing or has no stops (e.g. during the cover pre-generation pass).
+ */
+function resolveCoverColors(
+    cover: string,
+    slug: string
+): readonly [string, string] {
+    if (cover === generatedCoverPath(slug)) return coverGradientForSlug(slug);
+    try {
+        const svg = fs.readFileSync(path.join(PUBLIC_DIRECTORY, cover), 'utf8');
+        const stops = [
+            ...svg.matchAll(/stop-color="(#[0-9a-fA-F]{3,8})"/g),
+        ].map((match) => match[1]);
+        if (stops.length >= 2) return [stops[0], stops[1]];
+        if (stops.length === 1) return [stops[0], stops[0]];
+    } catch {
+        // fall through to the deterministic pair below
+    }
+    return coverGradientForSlug(slug);
+}
+
 function toSummary(article: ParsedArticle): ArticleSummary {
     const { slug, data, content } = article;
+    const cover = data.cover ?? generatedCoverPath(slug);
     return {
         slug,
         title: data.title ?? slug,
@@ -78,7 +110,8 @@ function toSummary(article: ParsedArticle): ArticleSummary {
         date: data.date ?? '',
         updated: data.updated,
         tags: Array.isArray(data.tags) ? data.tags : [],
-        cover: data.cover ?? generatedCoverPath(slug),
+        cover,
+        coverColors: resolveCoverColors(cover, slug),
         readingMinutes: estimateReadingMinutes(content),
     };
 }

--- a/src/utils/generateArticleCover.ts
+++ b/src/utils/generateArticleCover.ts
@@ -105,6 +105,15 @@ export function generatedCoverPath(slug: string): string {
 }
 
 /**
+ * The [from, to] gradient pair a generated cover is built from, chosen
+ * deterministically per slug. Exported so the article card can tint itself with
+ * the same colours as its thumbnail without re-parsing the generated SVG.
+ */
+export function coverGradientForSlug(slug: string): readonly [string, string] {
+    return COVER_GRADIENTS[hashString(slug) % COVER_GRADIENTS.length];
+}
+
+/**
  * Builds a complete 1200x630 SVG cover string for an article. The gradient is
  * chosen deterministically from the slug, so rebuilds are reproducible.
  */
@@ -117,11 +126,12 @@ export function buildArticleCoverSvg({
     title: string;
     tag?: string;
 }): string {
-    const [from, to] = COVER_GRADIENTS[hashString(slug) % COVER_GRADIENTS.length];
+    const [from, to] = coverGradientForSlug(slug);
     const gradientId = `bg-${slug}`;
     const glowId = `glow-${slug}`;
     const lines = wrapTitleLines(title);
-    const firstLineY = TITLE_CENTER_Y - ((lines.length - 1) * TITLE_LINE_HEIGHT) / 2;
+    const firstLineY =
+        TITLE_CENTER_Y - ((lines.length - 1) * TITLE_LINE_HEIGHT) / 2;
 
     const tagLabel = tag?.trim().toUpperCase();
     const tagText = tagLabel


### PR DESCRIPTION
- On hover, each article card glows in a soft, top-to-bottom gradient coloured to match its cover thumbnail, fading in slowly (700ms).
- Cover colours are resolved at build time in posts.ts (ArticleSummary.coverColors): generated covers reuse their gradient pair (exposed as coverGradientForSlug), author covers are parsed from their SVG. So any new article gets a matching glow automatically, no config.
- Colocated CSS Module with @apply for the utility-mappable rules; very soft, with the dark-mode strength raised (8% light / 14% dark) so the glow stays visible against the near-black background.