### PR TITLE
feat: soft per-card aurora glow on project-card hover

### DIFF
--- a/src/components/pages/home/ProjectsArea/ProjectCard/ProjectCard.module.css
+++ b/src/components/pages/home/ProjectsArea/ProjectCard/ProjectCard.module.css
@@ -1,0 +1,59 @@
+@reference "tailwindcss";
+
+/* Soft, multi-colour aurora glow revealed on project-card hover (#work), anchored
+   in the top-left corner. Three translucent radial washes are layered on a
+   ::before behind the card content (the card is `relative isolate`, so the negative
+   z-index keeps the wash under the text).
+
+   The three hues (--glow-a/b/c) are generated per card from its index in
+   ProjectCard (golden-angle spaced), so every card has a different gradient and any
+   project added to contents.ts gets its own automatically. This file owns only the
+   placement, softness, and theme handling. Deliberately barely noticeable: low
+   per-hue strength with a wide, diffuse falloff, stepped up a touch in dark mode.
+   Utility-mappable rules use @apply; only the gradient stack and its strength
+   variable are raw CSS. */
+.card {
+    --glow-strength: 5%;
+}
+
+@media (prefers-color-scheme: dark) {
+    .card {
+        --glow-strength: 6%;
+    }
+}
+
+.card::before {
+    @apply pointer-events-none absolute inset-0 z-[-1] rounded-[inherit] opacity-0 content-[''] motion-safe:transition-opacity motion-safe:duration-300;
+    background-image:
+        radial-gradient(
+            80% 85% at 0% 0%,
+            color-mix(
+                in oklab,
+                var(--glow-a, var(--foreground)) var(--glow-strength),
+                transparent
+            ),
+            transparent 78%
+        ),
+        radial-gradient(
+            70% 75% at 20% 4%,
+            color-mix(
+                in oklab,
+                var(--glow-b, var(--foreground)) var(--glow-strength),
+                transparent
+            ),
+            transparent 75%
+        ),
+        radial-gradient(
+            65% 70% at 2% 24%,
+            color-mix(
+                in oklab,
+                var(--glow-c, var(--foreground)) var(--glow-strength),
+                transparent
+            ),
+            transparent 72%
+        );
+}
+
+.card:hover::before {
+    @apply opacity-100;
+}

--- a/src/components/pages/home/ProjectsArea/ProjectCard/index.tsx
+++ b/src/components/pages/home/ProjectsArea/ProjectCard/index.tsx
@@ -2,11 +2,38 @@ import ExternalLinkIcon from '@/components/icons/external-link';
 import GithubIcon from '@/components/icons/github';
 import Tag from '@/components/pages/common/Tag';
 import ProjectLink from '@/components/pages/home/ProjectsArea/ProjectLink';
+import styles from '@/components/pages/home/ProjectsArea/ProjectCard/ProjectCard.module.css';
 import { Project } from '@/components/pages/home/ProjectsArea/contents';
+import { cn } from '@/utils/cn';
+import type { CSSProperties } from 'react';
 
-export default function ProjectCard({ project }: { project: Project }) {
+export default function ProjectCard({
+    project,
+    index,
+}: {
+    project: Project;
+    index: number;
+}) {
+    // Give every card its own multi-hue corner glow, generated from its position
+    // with the golden angle so consecutive cards land far apart on the colour
+    // wheel. Driven only by the index, so any project added to contents.ts gets a
+    // fresh, distinct gradient automatically. The three hues feed the layered
+    // washes in ProjectCard.module.css; softness/theme handling live there.
+    const hue = (index * 137.508) % 360;
+    const glow = {
+        '--glow-a': `oklch(0.72 0.16 ${hue})`,
+        '--glow-b': `oklch(0.72 0.16 ${hue + 40})`,
+        '--glow-c': `oklch(0.72 0.16 ${hue + 80})`,
+    } as CSSProperties;
+
     return (
-        <li className="border-foreground/10 hover:border-foreground/30 flex flex-col rounded-2xl border p-6 transition-all duration-300 hover:shadow-lg sm:p-8">
+        <li
+            style={glow}
+            className={cn(
+                styles.card,
+                'border-foreground/10 hover:border-foreground/30 relative isolate flex flex-col rounded-2xl border p-6 transition-all duration-300 hover:shadow-lg sm:p-8'
+            )}
+        >
             <p className="text-foreground/60 text-xs font-bold tracking-wide uppercase">
                 {project.category}
             </p>

--- a/src/components/pages/home/ProjectsArea/index.tsx
+++ b/src/components/pages/home/ProjectsArea/index.tsx
@@ -18,10 +18,11 @@ export default function ProjectsArea() {
                 </p>
 
                 <ul className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
-                    {projects.map((project) => (
+                    {projects.map((project, index) => (
                         <ProjectCard
                             key={project.repoURL}
                             project={project}
+                            index={index}
                         />
                     ))}
                 </ul>


### PR DESCRIPTION
- On hover, each project card reveals a soft, multi-colour aurora in the top-left corner.
- The hues are generated per card from its index (golden-angle spaced), so every card differs and any project added to contents.ts gets its own distinct gradient automatically, no per-project config.
- Colocated CSS Module using @apply for utility-mappable rules; deliberately barely noticeable (5% light / 6% dark, wide diffuse falloff), theme-aware, hover-only via opacity, no position shift.