### PR TITLE
feat: smooth-scroll to hash sections, sync URL while scrolling home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,13 @@ import ContactArea from '@/components/pages/home/ContactArea';
 import HeroArea from '@/components/pages/home/HeroArea';
 import ProjectsArea from '@/components/pages/home/ProjectsArea';
 import SkillsArea from '@/components/pages/home/SkillsArea';
+import SectionUrlSync from '@/components/layout/SectionUrlSync';
 
 export default function Home() {
     return (
         <main className="home-sections">
+            <SectionUrlSync />
+
             <HeroArea />
 
             <AboutMeArea />

--- a/src/components/layout/HashScroll/hooks/useHashScroll.ts
+++ b/src/components/layout/HashScroll/hooks/useHashScroll.ts
@@ -1,14 +1,24 @@
 'use client';
 
 import { useEffect } from 'react';
+import { lockScrollSync } from '@/components/layout/scrollSyncLock';
+
+// How long to let web fonts settle the content above the target before gliding,
+// so the section's final offset is known. Capped so the glide is never delayed
+// noticeably even if fonts are slow.
+const SETTLE_TIMEOUT_MS = 300;
 
 /**
- * Reliably scrolls to the URL fragment on initial load. `scroll-behavior: smooth`
- * on <html> makes the browser's native fragment scroll unreliable: it can start
- * before layout settles and get interrupted, leaving the visitor short of the
- * target. So we re-run the scroll ourselves after paint and again after the load
- * event (once images have sized), with smooth scrolling momentarily disabled so
- * the jump is instant and cannot be interrupted.
+ * On a direct visit to a URL with a fragment (e.g. /#skills), glide smoothly to
+ * that section instead of letting the browser snap to it.
+ *
+ * `scroll-behavior: smooth` on <html> makes the browser's own fragment scroll
+ * unreliable: it can start before layout settles, get interrupted, and leave the
+ * visitor short of the target. So we take over: snap to the top instantly (so the
+ * move reads as a deliberate glide down rather than an abrupt jump), wait a beat
+ * for fonts to settle the offset, then smooth-scroll to the section ourselves.
+ * The section -> URL sync is held off for the duration so it does not rewrite the
+ * hash to each section the glide passes through.
  */
 export function useHashScroll() {
     useEffect(() => {
@@ -16,23 +26,49 @@ export function useHashScroll() {
         if (hash.length < 2) return;
 
         const id = decodeURIComponent(hash.slice(1));
+        if (!document.getElementById(id)) return;
 
-        const scrollToTarget = () => {
-            const target = document.getElementById(id);
-            if (!target) return;
-            const root = document.documentElement;
-            const previousBehavior = root.style.scrollBehavior;
-            root.style.scrollBehavior = 'auto';
-            target.scrollIntoView();
-            root.style.scrollBehavior = previousBehavior;
+        const prefersReducedMotion = window.matchMedia(
+            '(prefers-reduced-motion: reduce)'
+        ).matches;
+
+        // Keep the URL sync quiet across the whole take-over (settle + glide).
+        lockScrollSync(1500);
+
+        // Snap to the top instantly, overriding the global smooth behavior, so
+        // the glide has somewhere to travel from.
+        const root = document.documentElement;
+        const previousBehavior = root.style.scrollBehavior;
+        root.style.scrollBehavior = 'auto';
+        window.scrollTo(0, 0);
+        root.style.scrollBehavior = previousBehavior;
+
+        let cancelled = false;
+        let settleTimer = 0;
+
+        const glideToTarget = () => {
+            if (cancelled) return;
+            // Re-lock for the glide itself in case fonts settled slowly.
+            lockScrollSync(1000);
+            document.getElementById(id)?.scrollIntoView({
+                behavior: prefersReducedMotion ? 'auto' : 'smooth',
+            });
         };
 
-        const frame = requestAnimationFrame(scrollToTarget);
-        window.addEventListener('load', scrollToTarget, { once: true });
+        // Glide once fonts are ready, but never wait longer than the cap.
+        const settle = new Promise<void>((resolve) => {
+            settleTimer = window.setTimeout(resolve, SETTLE_TIMEOUT_MS);
+        });
+        Promise.race([document.fonts?.ready ?? Promise.resolve(), settle]).then(
+            () => {
+                if (cancelled) return;
+                requestAnimationFrame(glideToTarget);
+            }
+        );
 
         return () => {
-            cancelAnimationFrame(frame);
-            window.removeEventListener('load', scrollToTarget);
+            cancelled = true;
+            window.clearTimeout(settleTimer);
         };
     }, []);
 }

--- a/src/components/layout/Navbar/NavItem.tsx
+++ b/src/components/layout/Navbar/NavItem.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { cn } from '@/utils/cn';
 import type { NavItemData } from '@/components/layout/Navbar/contents';
+import { lockScrollSync } from '@/components/layout/scrollSyncLock';
 
 interface NavItemProps {
     item: NavItemData;
@@ -16,6 +17,13 @@ export default function NavItem({
     variant = 'pill',
     onNavigate,
 }: NavItemProps) {
+    // A section link smooth-scrolls in-page; hold the URL sync off so the hash
+    // lands on the clicked section instead of every section glided past.
+    const handleClick = () => {
+        if (item.sectionId) lockScrollSync(1000);
+        onNavigate?.();
+    };
+
     const className = cn(
         'block text-sm transition-colors',
         variant === 'pill'
@@ -49,7 +57,7 @@ export default function NavItem({
             <Link
                 href={item.href}
                 aria-current={active ? 'page' : undefined}
-                onClick={onNavigate}
+                onClick={handleClick}
                 className={className}
             >
                 {item.label}

--- a/src/components/layout/Navbar/NavLogo.tsx
+++ b/src/components/layout/Navbar/NavLogo.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { MouseEvent } from 'react';
 import Shibbir from '@/components/icons/shibbir';
+import { lockScrollSync } from '@/components/layout/scrollSyncLock';
 
 interface NavLogoProps {
     className?: string;
@@ -35,6 +36,9 @@ export default function NavLogo({
         onNavigate?.();
         if (pathname !== '/') return;
         event.preventDefault();
+        // Hold the URL sync off so the hash clears cleanly to "/" instead of
+        // being rewritten to each section the upward glide passes.
+        lockScrollSync(1000);
         window.scrollTo({ top: 0, behavior: 'smooth' });
         window.history.replaceState(
             window.history.state,

--- a/src/components/layout/SectionUrlSync/hooks/useSectionUrlSync.ts
+++ b/src/components/layout/SectionUrlSync/hooks/useSectionUrlSync.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { isScrollSyncLocked } from '@/components/layout/scrollSyncLock';
+
+/**
+ * Reflects the section currently in view (`activeId`) into the URL hash with
+ * `replaceState`, so scrolling the home page keeps the address bar in sync
+ * without flooding the history stack. The hero clears the hash back to the bare
+ * path. Writes are skipped while a programmatic scroll is in flight (see
+ * scrollSyncLock), so the hash is not rewritten to every section a glide passes.
+ */
+export function useSectionUrlSync(activeId: string | null, heroId: string) {
+    const pathname = usePathname();
+
+    useEffect(() => {
+        if (activeId === null || isScrollSyncLocked()) return;
+
+        const targetHash = activeId === heroId ? '' : `#${activeId}`;
+        if (window.location.hash === targetHash) return;
+
+        window.history.replaceState(
+            window.history.state,
+            '',
+            `${pathname}${window.location.search}${targetHash}`
+        );
+    }, [activeId, heroId, pathname]);
+}

--- a/src/components/layout/SectionUrlSync/index.tsx
+++ b/src/components/layout/SectionUrlSync/index.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { heroId, sectionIds } from '@/components/layout/Navbar/contents';
+import { useScrollSpy } from '@/components/layout/Navbar/hooks/useScrollSpy';
+import { useSectionUrlSync } from '@/components/layout/SectionUrlSync/hooks/useSectionUrlSync';
+
+// Stable reference (the spy re-subscribes whenever this array identity changes),
+// the hero plus every section anchor, in document order.
+const spyIds = [heroId, ...sectionIds];
+
+/**
+ * Home page only: keeps the URL hash pointing at the section in view as the
+ * visitor scrolls (#about, #work, ...), clearing it back to "/" at the hero.
+ * Renders nothing.
+ */
+export default function SectionUrlSync() {
+    const activeId = useScrollSpy(spyIds);
+    useSectionUrlSync(activeId, heroId);
+    return null;
+}

--- a/src/components/layout/scrollSyncLock.ts
+++ b/src/components/layout/scrollSyncLock.ts
@@ -1,0 +1,24 @@
+/**
+ * Coordinates programmatic (animated) scrolls with the section -> URL sync.
+ *
+ * While the page is being scrolled programmatically (the initial fragment glide,
+ * a nav-link click, or the logo's scroll-to-top), the sync stands down so it does
+ * not rewrite the hash to every section the page glides past on the way to its
+ * destination. The initiator of the scroll already owns the final URL, so the
+ * sync simply waits for the animation to finish.
+ *
+ * Time-based with a safety cap rather than an explicit begin/end pair: a missed
+ * "end" can only ever leave the sync briefly idle, never stuck off.
+ */
+let unlockAt = 0;
+
+/** Suppress the section -> URL sync for the next `durationMs`. */
+export function lockScrollSync(durationMs: number) {
+    const until = Date.now() + durationMs;
+    if (until > unlockAt) unlockAt = until;
+}
+
+/** Whether the section -> URL sync is currently suppressed. */
+export function isScrollSyncLocked() {
+    return Date.now() < unlockAt;
+}


### PR DESCRIPTION
Direct visits to a fragment (e.g. /#skills) now glide smoothly to the section instead of snapping: snap to top, let fonts settle the offset, then smooth scrollIntoView (respecting reduced motion).

The home page reflects the in-view section into the URL hash as you scroll (#about, #work, ...), clearing back to "/" at the hero, via replaceState so history is not flooded.

A shared scroll-sync lock holds the URL sync off during programmatic scrolls (the initial glide, nav-link clicks, the logo's scroll-to-top) so the hash lands on the destination instead of every section passed.