### PR TITLE
feat: elevate article detail page into a knowledge platform

### DIFF
--- a/content/articles/01-redis-caching-strategies.md
+++ b/content/articles/01-redis-caching-strategies.md
@@ -2,8 +2,16 @@
 title: 'Caching Strategies with Redis'
 description: 'Cache-aside, write-through, TTLs, and invalidation: choosing a Redis caching strategy that fits your read and write patterns.'
 date: '2025-12-15'
+updated: '2026-01-08'
 tags: ['Redis', 'Backend', 'Performance']
 cover: '/images/articles/redis-caching-strategies.svg'
+category: 'Backend'
+difficulty: 'Intermediate'
+tech: ['Redis', 'Node.js']
+learn:
+    - 'When cache-aside fits and when to reach for write-through'
+    - 'Picking an invalidation approach for your freshness needs'
+    - 'Guarding hot keys against cache stampedes'
 ---
 
 Caching is the fastest way to make a read-heavy app feel instant, and the fastest way to serve stale data if you get invalidation wrong.
@@ -11,6 +19,8 @@ Caching is the fastest way to make a read-heavy app feel instant, and the fastes
 ## Cache-aside is the default
 
 The app checks the cache, falls back to the database on a miss, and writes the result back:
+
+![Cache-aside read path: the app reads from Redis, queries the database on a miss, then writes the value back with a TTL.](/images/articles/inline/redis-cache-aside.svg)
 
 ```ts
 let user = await redis.get(key);

--- a/content/articles/06-understanding-vector-embeddings.md
+++ b/content/articles/06-understanding-vector-embeddings.md
@@ -4,6 +4,16 @@ description: 'What embeddings actually are, why cosine similarity works, and how
 date: '2026-04-05'
 tags: ['AI', 'Embeddings', 'Search']
 cover: '/images/articles/understanding-vector-embeddings.svg'
+category: 'AI Engineering'
+difficulty: 'Beginner'
+tech: ['Python', 'NumPy', 'OpenAI']
+series:
+    name: 'Building an LLM Knowledge System'
+    order: 1
+learn:
+    - 'What an embedding vector represents and where it comes from'
+    - 'Why cosine similarity captures meaning better than keyword overlap'
+    - 'How semantic search answers questions exact-match search misses'
 ---
 
 An embedding turns text into a list of numbers that captures meaning. Similar ideas land close together in that space, which is what makes semantic search possible.

--- a/content/articles/11-prompt-engineering-patterns.md
+++ b/content/articles/11-prompt-engineering-patterns.md
@@ -3,6 +3,16 @@ title: 'Prompt Engineering Patterns for Production'
 description: 'Reusable prompt structures that make model output predictable: role framing, few-shot examples, and structured output you can parse.'
 date: '2026-06-19'
 tags: ['AI', 'LLM', 'Prompt Engineering']
+category: 'AI Engineering'
+difficulty: 'Intermediate'
+tech: ['LLM', 'JSON Schema']
+series:
+    name: 'Building an LLM Knowledge System'
+    order: 2
+learn:
+    - 'How role framing steers a model toward the answer you want'
+    - 'When few-shot examples beat longer instructions'
+    - 'How to enforce structured output your code can parse safely'
 ---
 
 A prompt is an interface. In a demo you can tweak wording by feel, but in production you need structures that behave the same way every run. These patterns get you there.

--- a/content/articles/12-rag-pipeline-qdrant-gemini.md
+++ b/content/articles/12-rag-pipeline-qdrant-gemini.md
@@ -2,8 +2,20 @@
 title: 'Building a RAG Pipeline with Qdrant and Gemini'
 description: 'A practical walkthrough of retrieval-augmented generation: chunking, embeddings, vector search with Qdrant, and grounding answers with Gemini.'
 date: '2026-06-20'
+updated: '2026-06-26'
 tags: ['AI', 'RAG', 'Qdrant', 'Embeddings']
 cover: '/images/articles/rag-pipeline-qdrant-gemini.svg'
+category: 'AI Engineering'
+difficulty: 'Advanced'
+tech: ['Qdrant', 'Gemini', 'Python', 'FastAPI']
+series:
+    name: 'Building an LLM Knowledge System'
+    order: 3
+learn:
+    - 'How to chunk documents so retrieval stays relevant'
+    - 'Storing and querying embeddings in Qdrant'
+    - 'Grounding Gemini answers in retrieved context to cut hallucinations'
+    - 'Wiring the retrieve-then-generate loop behind an API'
 ---
 
 Retrieval-augmented generation (RAG) grounds a language model in your own data, so answers stay accurate and current without retraining. Here is the pipeline I reach for.

--- a/public/images/articles/inline/redis-cache-aside.svg
+++ b/public/images/articles/inline/redis-cache-aside.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 360" role="img" aria-label="Cache-aside read path diagram: the app reads from Redis, falls back to the database on a miss, then writes the value back to the cache.">
+  <style>
+    .card { fill: #ffffff; }
+    .frame { fill: none; stroke: #e2e8f0; }
+    .box { fill: #f8fafc; stroke: #cbd5e1; }
+    .title { fill: #0f172a; font: 700 22px ui-sans-serif, system-ui, sans-serif; }
+    .sub { fill: #64748b; font: 400 14px ui-sans-serif, system-ui, sans-serif; }
+    .node { fill: #0f172a; font: 600 17px ui-sans-serif, system-ui, sans-serif; }
+    .node-sub { fill: #64748b; font: 400 12px ui-monospace, monospace; }
+    .legend { fill: #475569; font: 400 13px ui-sans-serif, system-ui, sans-serif; }
+    .badge { fill: #dc2626; }
+    .badge-text { fill: #ffffff; font: 700 12px ui-sans-serif, system-ui, sans-serif; }
+    .flow { stroke: #94a3b8; stroke-width: 2; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .card { fill: #0b1120; }
+      .frame { stroke: #1e293b; }
+      .box { fill: #111a2e; stroke: #334155; }
+      .title { fill: #e2e8f0; }
+      .sub { fill: #94a3b8; }
+      .node { fill: #e2e8f0; }
+      .node-sub { fill: #94a3b8; }
+      .legend { fill: #94a3b8; }
+      .flow { stroke: #475569; }
+    }
+  </style>
+
+  <defs>
+    <marker id="arrowR" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#94a3b8" />
+    </marker>
+  </defs>
+
+  <rect class="card" x="0" y="0" width="820" height="360" rx="16" />
+  <rect class="frame" x="1" y="1" width="818" height="358" rx="16" />
+
+  <text class="title" x="40" y="56">Cache-aside read path</text>
+  <text class="sub" x="40" y="82">The app owns the cache; the database stays the source of truth.</text>
+
+  <!-- Nodes -->
+  <g>
+    <rect class="box" x="50" y="150" width="180" height="84" rx="12" />
+    <text class="node" x="140" y="188" text-anchor="middle">App server</text>
+    <text class="node-sub" x="140" y="210" text-anchor="middle">request handler</text>
+
+    <rect class="box" x="320" y="150" width="180" height="84" rx="12" />
+    <text class="node" x="410" y="188" text-anchor="middle">Redis</text>
+    <text class="node-sub" x="410" y="210" text-anchor="middle">key → value, TTL</text>
+
+    <rect class="box" x="590" y="150" width="180" height="84" rx="12" />
+    <text class="node" x="680" y="188" text-anchor="middle">Database</text>
+    <text class="node-sub" x="680" y="210" text-anchor="middle">source of truth</text>
+  </g>
+
+  <!-- Flow arrows: top track points right (read + miss), bottom track points left (row + fill) -->
+  <path class="flow" d="M236 176 L308 176" marker-end="url(#arrowR)" />
+  <path class="flow" d="M506 176 L578 176" marker-end="url(#arrowR)" />
+  <path class="flow" d="M584 208 L512 208" marker-end="url(#arrowR)" />
+  <path class="flow" d="M314 208 L242 208" marker-end="url(#arrowR)" />
+
+  <!-- Step badges -->
+  <g>
+    <circle class="badge" cx="272" cy="160" r="11" /><text class="badge-text" x="272" y="164" text-anchor="middle">1</text>
+    <circle class="badge" cx="542" cy="160" r="11" /><text class="badge-text" x="542" y="164" text-anchor="middle">2</text>
+    <circle class="badge" cx="548" cy="224" r="11" /><text class="badge-text" x="548" y="228" text-anchor="middle">3</text>
+    <circle class="badge" cx="278" cy="224" r="11" /><text class="badge-text" x="278" y="228" text-anchor="middle">4</text>
+  </g>
+
+  <!-- Legend -->
+  <text class="legend" x="40" y="300">1 · read key   ·   2 · miss → query   ·   3 · row returned   ·   4 · set key (TTL) + return</text>
+</svg>

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -4,13 +4,29 @@ import Breadcrumb from '@/components/layout/Breadcrumb';
 import ArticleContent from '@/components/pages/articles/ArticleContent';
 import ArticleCover from '@/components/pages/articles/ArticleCover';
 import ArticleGrid from '@/components/pages/articles/ArticleGrid';
+import ArticleMeta from '@/components/pages/articles/ArticleMeta';
+import ArticlePager from '@/components/pages/articles/ArticlePager';
+import ImageLightbox from '@/components/pages/articles/ImageLightbox';
+import ReadingProgress from '@/components/pages/articles/ReadingProgress';
+import SeriesNav from '@/components/pages/articles/SeriesNav';
+import TableOfContents from '@/components/pages/articles/TableOfContents';
+import MobileTableOfContents from '@/components/pages/articles/TableOfContents/MobileTableOfContents';
 import TagLink from '@/components/pages/articles/TagLink';
+import TechStack from '@/components/pages/articles/TechStack';
+import WhatYoullLearn from '@/components/pages/articles/WhatYoullLearn';
 import MermaidRenderer from '@/components/pages/articles/MermaidRenderer';
 import CodeBlockCopy from '@/components/pages/articles/CodeBlock';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { buildArticleJsonLd } from '@/utils/articleJsonLd';
-import { formatDate } from '@/utils/formatDate';
-import { getAllArticles, getArticle, getRelatedArticles } from '@/lib/posts';
+import { jetBrainsMono } from '@/config/monoFont';
+import { cn } from '@/utils/cn';
+import {
+    getAdjacentArticles,
+    getAllArticles,
+    getArticle,
+    getRelatedArticles,
+    getSeriesForArticle,
+} from '@/lib/posts';
 
 export const dynamicParams = false;
 
@@ -56,53 +72,101 @@ export default async function ArticlePage({
     if (!article) notFound();
 
     const related = getRelatedArticles(slug, 4);
-
-    const header = (
-        <header>
-            <p className="text-foreground/60 text-sm">
-                <time dateTime={article.date}>{formatDate(article.date)}</time>
-                {' · '}
-                {article.readingMinutes} min read
-            </p>
-            <h1 className="mt-3 text-3xl font-bold sm:text-4xl">
-                {article.title}
-            </h1>
-            <ul className="mt-6 flex flex-wrap gap-2">
-                {article.tags.map((tag) => (
-                    <TagLink
-                        key={tag}
-                        tag={tag}
-                        className="px-3 py-1 text-sm"
-                    />
-                ))}
-            </ul>
-            {article.description && (
-                <p className="text-foreground/80 mt-6 text-lg leading-relaxed">
-                    {article.description}
-                </p>
-            )}
-        </header>
-    );
+    const series = getSeriesForArticle(slug);
+    const { previous, next } = getAdjacentArticles(slug);
 
     return (
-        <main className="container mx-auto px-4 py-20 sm:py-28">
+        <main
+            className={cn(
+                jetBrainsMono.variable,
+                'container mx-auto px-4 py-20 sm:py-28'
+            )}
+        >
+            <ReadingProgress accentColors={article.coverColors} />
             <Breadcrumb currentName={article.title} />
+
             <article>
                 <div className="grid items-center gap-8 lg:grid-cols-2 lg:gap-12">
                     <ArticleCover
                         src={article.cover}
                         className="h-auto rounded-2xl"
                     />
-                    {header}
+                    <header>
+                        <ArticleMeta
+                            date={article.date}
+                            updated={article.updated}
+                            readingMinutes={article.readingMinutes}
+                            difficulty={article.difficulty}
+                        />
+                        <h1 className="mt-4 text-3xl font-bold sm:text-4xl">
+                            {article.title}
+                        </h1>
+                        {article.description && (
+                            <p className="text-foreground/80 mt-5 text-lg leading-relaxed">
+                                {article.description}
+                            </p>
+                        )}
+                        <ul className="mt-6 flex flex-wrap gap-2">
+                            {article.tags.map((tag) => (
+                                <TagLink
+                                    key={tag}
+                                    tag={tag}
+                                    className="px-3 py-1 text-sm"
+                                />
+                            ))}
+                        </ul>
+                        {article.tech.length > 0 && (
+                            <TechStack
+                                tech={article.tech}
+                                className="mt-5"
+                            />
+                        )}
+                    </header>
                 </div>
 
                 <div className="via-foreground/50 mt-12 h-px bg-linear-to-r from-transparent to-transparent" />
 
-                <ArticleContent html={article.html} />
+                <div className="mt-12 lg:grid lg:grid-cols-[minmax(0,1fr)_15rem] lg:gap-12 xl:gap-16">
+                    <div className="min-w-0">
+                        {series && (
+                            <SeriesNav
+                                series={series}
+                                currentSlug={slug}
+                                accentColors={article.coverColors}
+                                className="mb-8"
+                            />
+                        )}
+                        {article.learn.length > 0 && (
+                            <WhatYoullLearn
+                                items={article.learn}
+                                accentColors={article.coverColors}
+                                className="mb-8"
+                            />
+                        )}
+                        <MobileTableOfContents
+                            toc={article.toc}
+                            accentColors={article.coverColors}
+                        />
 
-                <MermaidRenderer />
+                        <ArticleContent html={article.html} />
 
-                <CodeBlockCopy />
+                        <MermaidRenderer />
+                        <CodeBlockCopy />
+                        <ImageLightbox />
+
+                        <ArticlePager
+                            previous={previous}
+                            next={next}
+                        />
+                    </div>
+
+                    <aside className="hidden lg:block">
+                        <TableOfContents
+                            toc={article.toc}
+                            accentColors={article.coverColors}
+                        />
+                    </aside>
+                </div>
             </article>
 
             {related.length > 0 && (

--- a/src/components/pages/articles/ArticleContent/ArticleContent.module.css
+++ b/src/components/pages/articles/ArticleContent/ArticleContent.module.css
@@ -196,6 +196,20 @@
     }
 }
 
+/* Anchored headings sit clear of the floating navbar and the reading-progress
+   bar when reached via a table-of-contents link (the TOC links to these ids). */
+.content :where(h2, h3) {
+    scroll-margin-top: 6rem;
+}
+
+/* Content images: a rounded hairline frame so screenshots and diagrams read as
+   deliberate figures. ImageLightbox adds the zoom cursor and click-to-expand on
+   the client; gist images keep their own styling. */
+.content :where(img):not(:where(.gist-embed *)) {
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+}
+
 /* Mermaid source. On the client, MermaidRenderer hides this <pre> and replaces
    it with an interactive diagram; without JS the raw definition stays visible as
    a fallback. not-prose already strips Typography's code-block styling. */

--- a/src/components/pages/articles/ArticleMeta.tsx
+++ b/src/components/pages/articles/ArticleMeta.tsx
@@ -1,0 +1,42 @@
+import DifficultyBadge from '@/components/pages/articles/DifficultyBadge';
+import { formatDate } from '@/utils/formatDate';
+import type { ArticleDifficulty } from '@/lib/posts';
+
+/**
+ * The byline strip above the article title: difficulty, publish date, reading
+ * time, and an "Updated" stamp when the post has been revised since publishing.
+ * Each field is optional, so the row stays clean for sparse frontmatter.
+ */
+export default function ArticleMeta({
+    date,
+    updated,
+    readingMinutes,
+    difficulty,
+}: {
+    date: string;
+    updated?: string;
+    readingMinutes: number;
+    difficulty?: ArticleDifficulty;
+}) {
+    const wasUpdated = updated && updated !== date ? updated : null;
+
+    return (
+        <div className="text-foreground/60 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+            {difficulty && <DifficultyBadge level={difficulty} />}
+            {date && <time dateTime={date}>{formatDate(date)}</time>}
+            <span aria-hidden>·</span>
+            <span>{readingMinutes} min read</span>
+            {wasUpdated && (
+                <>
+                    <span aria-hidden>·</span>
+                    <span>
+                        Updated{' '}
+                        <time dateTime={wasUpdated}>
+                            {formatDate(wasUpdated)}
+                        </time>
+                    </span>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/components/pages/articles/ArticlePager.tsx
+++ b/src/components/pages/articles/ArticlePager.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import ChevronIcon from '@/components/icons/chevron';
+import { cn } from '@/utils/cn';
+import type { ArticleSummary } from '@/lib/posts';
+
+interface PagerLinkProps {
+    article: ArticleSummary;
+    direction: 'previous' | 'next';
+    /** Pin to the right column and right-align (only when a previous card also
+     *  occupies the left column, so a lone Next card stays left-aligned). */
+    alignEnd?: boolean;
+}
+
+/** One pager card. "Next" carries a trailing arrow; "Previous" a leading one. */
+function PagerLink({ article, direction, alignEnd = false }: PagerLinkProps) {
+    const isNext = direction === 'next';
+    return (
+        <Link
+            href={`/articles/${article.slug}`}
+            rel={isNext ? 'next' : 'prev'}
+            className={cn(
+                'border-foreground/10 hover:border-foreground/30 hover:bg-foreground/[0.02] group flex flex-col gap-2 rounded-xl border p-5 transition-colors',
+                alignEnd ? 'sm:col-start-2 sm:items-end sm:text-right' : ''
+            )}
+        >
+            <span className="text-foreground/50 flex items-center gap-1.5 text-xs font-semibold tracking-[0.08em] uppercase">
+                {!isNext && (
+                    <ChevronIcon className="size-3.5 -rotate-90 transition-transform group-hover:-translate-x-0.5" />
+                )}
+                {isNext ? 'Next' : 'Previous'}
+                {isNext && (
+                    <ChevronIcon className="size-3.5 rotate-90 transition-transform group-hover:translate-x-0.5" />
+                )}
+            </span>
+            <span className="group-hover:text-foreground font-semibold transition-colors">
+                {article.title}
+            </span>
+        </Link>
+    );
+}
+
+/**
+ * Previous/next navigation across the chronological feed, so a reader who
+ * reaches the end of one article can keep going. Renders nothing when the
+ * article has no neighbours (e.g. a lone post).
+ */
+export default function ArticlePager({
+    previous,
+    next,
+}: {
+    previous?: ArticleSummary;
+    next?: ArticleSummary;
+}) {
+    if (!previous && !next) return null;
+
+    return (
+        <nav
+            aria-label="More articles"
+            className="mt-16 grid gap-4 sm:grid-cols-2"
+        >
+            {previous && (
+                <PagerLink
+                    article={previous}
+                    direction="previous"
+                />
+            )}
+            {next && (
+                <PagerLink
+                    article={next}
+                    direction="next"
+                    alignEnd={Boolean(previous)}
+                />
+            )}
+        </nav>
+    );
+}

--- a/src/components/pages/articles/DifficultyBadge.tsx
+++ b/src/components/pages/articles/DifficultyBadge.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@/utils/cn';
+import type { ArticleDifficulty } from '@/lib/posts';
+
+/** Per-level colour, kept subtle so the badge reads as a label, not an alert. */
+const LEVEL_STYLES: Record<ArticleDifficulty, string> = {
+    Beginner:
+        'border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+    Intermediate:
+        'border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+    Advanced:
+        'border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+};
+
+/** Number of filled bars that signals the level at a glance. */
+const LEVEL_BARS: Record<ArticleDifficulty, number> = {
+    Beginner: 1,
+    Intermediate: 2,
+    Advanced: 3,
+};
+
+/** A small pill conveying an article's difficulty with a label and signal bars. */
+export default function DifficultyBadge({
+    level,
+    className,
+}: {
+    level: ArticleDifficulty;
+    className?: string;
+}) {
+    const filled = LEVEL_BARS[level];
+    return (
+        <span
+            className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                LEVEL_STYLES[level],
+                className
+            )}
+        >
+            <span
+                aria-hidden
+                className="flex items-end gap-0.5"
+            >
+                {[0, 1, 2].map((bar) => (
+                    <span
+                        key={bar}
+                        className={cn(
+                            'w-0.5 rounded-full bg-current',
+                            bar === 0 ? 'h-1.5' : bar === 1 ? 'h-2' : 'h-2.5',
+                            bar < filled ? 'opacity-100' : 'opacity-30'
+                        )}
+                    />
+                ))}
+            </span>
+            {level}
+        </span>
+    );
+}

--- a/src/components/pages/articles/ImageLightbox/LightboxOverlay.tsx
+++ b/src/components/pages/articles/ImageLightbox/LightboxOverlay.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import ChevronIcon from '@/components/icons/chevron';
+import CloseIcon from '@/components/icons/close';
+import { useModalChrome } from '@/components/pages/articles/hooks/useModalChrome';
+import { cn } from '@/utils/cn';
+import type { ArticleImage } from '@/components/pages/articles/ImageLightbox/hooks/useArticleImages';
+
+/** A round control button floating over the dimmed backdrop. Forwards `ref`
+ *  (React 19 ref-as-prop) so the overlay can focus the close button on open. */
+function OverlayButton({
+    className,
+    type,
+    children,
+    ...rest
+}: React.ComponentPropsWithRef<'button'>) {
+    return (
+        <button
+            type={type ?? 'button'}
+            className={cn(
+                'flex size-10 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur transition-colors hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-none',
+                className
+            )}
+            {...rest}
+        >
+            {children}
+        </button>
+    );
+}
+
+/**
+ * Full-screen image viewer over a dimmed backdrop. Closes on the close button,
+ * Escape, or a backdrop click; pages with the arrow buttons or Left/Right keys
+ * (wrapping around). Locks body scroll and restores focus to the trigger image
+ * on dismiss.
+ */
+export default function LightboxOverlay({
+    images,
+    index,
+    onIndexChange,
+    onClose,
+}: {
+    images: ArticleImage[];
+    index: number;
+    onIndexChange: (next: number) => void;
+    onClose: () => void;
+}) {
+    const closeRef = useRef<HTMLButtonElement>(null);
+    const hasMultiple = images.length > 1;
+
+    const goTo = useCallback(
+        (next: number) => {
+            const count = images.length;
+            onIndexChange((next + count) % count);
+        },
+        [images.length, onIndexChange]
+    );
+
+    // Scroll lock, focus management, and Escape live in the shared modal hook,
+    // mounted once; only the left/right paging re-binds as the index changes.
+    useModalChrome(onClose, closeRef);
+
+    useEffect(() => {
+        if (!hasMultiple) return;
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'ArrowRight') goTo(index + 1);
+            else if (event.key === 'ArrowLeft') goTo(index - 1);
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [hasMultiple, index, goTo]);
+
+    const image = images[index];
+
+    return createPortal(
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Image viewer"
+            className="fixed inset-0 z-[60] flex flex-col items-center justify-center bg-black/85 p-4 backdrop-blur-sm sm:p-8"
+            onClick={(event) => {
+                if (event.target === event.currentTarget) onClose();
+            }}
+        >
+            <div className="absolute top-4 right-4 z-10">
+                <OverlayButton
+                    ref={closeRef}
+                    aria-label="Close image viewer"
+                    onClick={onClose}
+                >
+                    <CloseIcon className="size-5" />
+                </OverlayButton>
+            </div>
+
+            {hasMultiple && (
+                <>
+                    <div className="absolute inset-y-0 left-4 z-10 flex items-center">
+                        <OverlayButton
+                            aria-label="Previous image"
+                            onClick={() => goTo(index - 1)}
+                        >
+                            <ChevronIcon className="size-5 -rotate-90" />
+                        </OverlayButton>
+                    </div>
+                    <div className="absolute inset-y-0 right-4 z-10 flex items-center">
+                        <OverlayButton
+                            aria-label="Next image"
+                            onClick={() => goTo(index + 1)}
+                        >
+                            <ChevronIcon className="size-5 rotate-90" />
+                        </OverlayButton>
+                    </div>
+                </>
+            )}
+
+            {/* eslint-disable-next-line @next/next/no-img-element -- raw markdown
+                image shown at native size; the export optimizer only wraps
+                build-time <ExportedImage> sources, not these runtime previews. */}
+            <img
+                src={image.src}
+                alt={image.alt}
+                className="max-h-[82vh] max-w-full rounded-lg object-contain shadow-2xl"
+                onClick={(event) => event.stopPropagation()}
+            />
+
+            <div className="mt-4 flex max-w-2xl flex-col items-center gap-1 text-center">
+                {image.alt && (
+                    <p className="text-sm text-white/80">{image.alt}</p>
+                )}
+                {hasMultiple && (
+                    <p className="text-xs text-white/50">
+                        {index + 1} / {images.length}
+                    </p>
+                )}
+            </div>
+        </div>,
+        document.body
+    );
+}

--- a/src/components/pages/articles/ImageLightbox/hooks/useArticleImages.ts
+++ b/src/components/pages/articles/ImageLightbox/hooks/useArticleImages.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface ArticleImage {
+    src: string;
+    alt: string;
+}
+
+/**
+ * Collects the content images in the article body (excluding embedded gists,
+ * which bring their own chrome) and makes each one open the lightbox: it sets a
+ * zoom cursor, exposes the image as a button to assistive tech, and wires click
+ * plus Enter/Space to `onActivate(index)`. Returns the gallery in document order
+ * so the overlay can page through it. All DOM tweaks are reverted on cleanup.
+ */
+export function useArticleImages(
+    onActivate: (index: number) => void
+): ArticleImage[] {
+    const [images, setImages] = useState<ArticleImage[]>([]);
+
+    useEffect(() => {
+        const elements = Array.from(
+            document.querySelectorAll<HTMLImageElement>('article .prose img')
+        ).filter((img) => !img.closest('.gist-embed'));
+        if (elements.length === 0) return;
+
+        const cleanups = elements.map((img, index) => {
+            const previousCursor = img.style.cursor;
+            const previousRole = img.getAttribute('role');
+            const previousTabIndex = img.getAttribute('tabindex');
+            const previousTitle = img.getAttribute('title');
+
+            img.style.cursor = 'zoom-in';
+            img.setAttribute('role', 'button');
+            img.setAttribute('tabindex', '0');
+            if (!previousTitle) img.setAttribute('title', 'Click to zoom');
+
+            const activate = () => onActivate(index);
+            const onKeyDown = (event: KeyboardEvent) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    activate();
+                }
+            };
+            img.addEventListener('click', activate);
+            img.addEventListener('keydown', onKeyDown);
+
+            return () => {
+                img.style.cursor = previousCursor;
+                if (previousRole === null) img.removeAttribute('role');
+                else img.setAttribute('role', previousRole);
+                if (previousTabIndex === null) img.removeAttribute('tabindex');
+                else img.setAttribute('tabindex', previousTabIndex);
+                if (previousTitle === null) img.removeAttribute('title');
+                img.removeEventListener('click', activate);
+                img.removeEventListener('keydown', onKeyDown);
+            };
+        });
+
+        setImages(elements.map((img) => ({ src: img.src, alt: img.alt })));
+
+        return () => {
+            for (const cleanup of cleanups) cleanup();
+            setImages([]);
+        };
+    }, [onActivate]);
+
+    return images;
+}

--- a/src/components/pages/articles/ImageLightbox/index.tsx
+++ b/src/components/pages/articles/ImageLightbox/index.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+import LightboxOverlay from '@/components/pages/articles/ImageLightbox/LightboxOverlay';
+import { useArticleImages } from '@/components/pages/articles/ImageLightbox/hooks/useArticleImages';
+
+/**
+ * Turns every content image in the article body into a click-to-zoom trigger for
+ * a full-screen viewer with keyboard navigation. Like the code and Mermaid
+ * enhancers, it owns no markup of its own (beyond the portalled overlay) and is
+ * a no-op on articles without images.
+ */
+export default function ImageLightbox() {
+    const [openIndex, setOpenIndex] = useState<number | null>(null);
+    const images = useArticleImages(setOpenIndex);
+
+    if (openIndex === null || images.length === 0) return null;
+
+    return (
+        <LightboxOverlay
+            images={images}
+            index={openIndex}
+            onIndexChange={setOpenIndex}
+            onClose={() => setOpenIndex(null)}
+        />
+    );
+}

--- a/src/components/pages/articles/MermaidRenderer/MermaidModal.tsx
+++ b/src/components/pages/articles/MermaidRenderer/MermaidModal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { createPortal } from 'react-dom';
 import CloseIcon from '@/components/icons/close';
+import { useModalChrome } from '@/components/pages/articles/hooks/useModalChrome';
 import MermaidIconButton from '@/components/pages/articles/MermaidRenderer/MermaidIconButton';
 import MermaidCopyButton from '@/components/pages/articles/MermaidRenderer/MermaidCopyButton';
 import MermaidStage from '@/components/pages/articles/MermaidRenderer/MermaidStage';
@@ -21,23 +22,7 @@ interface MermaidModalProps {
 export default function MermaidModal({ svg, source, onClose }: MermaidModalProps) {
     const closeRef = useRef<HTMLButtonElement>(null);
 
-    useEffect(() => {
-        const previouslyFocused = document.activeElement as HTMLElement | null;
-        const previousOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-        closeRef.current?.focus();
-
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') onClose();
-        };
-        document.addEventListener('keydown', onKeyDown);
-
-        return () => {
-            document.removeEventListener('keydown', onKeyDown);
-            document.body.style.overflow = previousOverflow;
-            previouslyFocused?.focus?.();
-        };
-    }, [onClose]);
+    useModalChrome(onClose, closeRef);
 
     return createPortal(
         <div

--- a/src/components/pages/articles/ReadingProgress/hooks/useReadingProgress.ts
+++ b/src/components/pages/articles/ReadingProgress/hooks/useReadingProgress.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks how far the reader has scrolled through the first `<article>` on the
+ * page, as a 0..1 fraction. Progress is measured against the article's own
+ * height (not the whole document), so the bar fills exactly as the body is read
+ * and ignores the header, footer, and related-posts tail. Recomputed on scroll
+ * and resize, throttled to one update per animation frame.
+ */
+export function useReadingProgress(): number {
+    const [progress, setProgress] = useState(0);
+
+    useEffect(() => {
+        const article = document.querySelector('article');
+        if (!article) return;
+
+        let frame = 0;
+        const measure = () => {
+            frame = 0;
+            const rect = article.getBoundingClientRect();
+            const scrollable = rect.height - window.innerHeight;
+            if (scrollable <= 0) {
+                setProgress(rect.top <= 0 ? 1 : 0);
+                return;
+            }
+            const scrolled = -rect.top;
+            setProgress(Math.min(1, Math.max(0, scrolled / scrollable)));
+        };
+        const onScroll = () => {
+            if (frame) return;
+            frame = requestAnimationFrame(measure);
+        };
+
+        measure();
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        return () => {
+            if (frame) cancelAnimationFrame(frame);
+            window.removeEventListener('scroll', onScroll);
+            window.removeEventListener('resize', onScroll);
+        };
+    }, []);
+
+    return progress;
+}

--- a/src/components/pages/articles/ReadingProgress/index.tsx
+++ b/src/components/pages/articles/ReadingProgress/index.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useReadingProgress } from '@/components/pages/articles/ReadingProgress/hooks/useReadingProgress';
+import { accentStyle } from '@/utils/accentStyle';
+
+/**
+ * A thin progress bar pinned to the top of the viewport that fills as the reader
+ * scrolls through the article body. It is tinted with the article's own cover
+ * accent so the page keeps a single colour identity. Decorative for sighted
+ * users but exposed as a progressbar for assistive tech.
+ */
+export default function ReadingProgress({
+    accentColors,
+}: {
+    accentColors: readonly [string, string];
+}) {
+    const progress = useReadingProgress();
+    const percent = Math.round(progress * 100);
+
+    return (
+        <div
+            role="progressbar"
+            aria-label="Reading progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={percent}
+            style={accentStyle(accentColors)}
+            className="fixed inset-x-0 top-0 z-50 h-[3px] print:hidden"
+        >
+            <div
+                style={{ transform: `scaleX(${progress})` }}
+                className="h-full origin-left bg-linear-to-r from-[var(--accent-from)] to-[var(--accent-to)]"
+            />
+        </div>
+    );
+}

--- a/src/components/pages/articles/SeriesNav.tsx
+++ b/src/components/pages/articles/SeriesNav.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import { accentStyle } from '@/utils/accentStyle';
+import { cn } from '@/utils/cn';
+import type { ArticleSeries } from '@/lib/posts';
+
+/**
+ * A tracker for multi-part tutorials: it names the series, shows "Part N of M",
+ * and lists every part as a stepper so the reader can jump across the set and
+ * always see where this article sits. Other parts link out; the current one is
+ * marked, not linked.
+ */
+export default function SeriesNav({
+    series,
+    currentSlug,
+    accentColors,
+    className,
+}: {
+    series: ArticleSeries;
+    currentSlug: string;
+    accentColors: readonly [string, string];
+    className?: string;
+}) {
+    const currentIndex = series.parts.findIndex(
+        (part) => part.slug === currentSlug
+    );
+    const position = currentIndex + 1;
+
+    return (
+        <section
+            aria-label={`Series: ${series.name}`}
+            style={accentStyle(accentColors)}
+            className={cn(
+                'border-foreground/10 bg-foreground/[0.02] rounded-2xl border p-5 sm:p-6',
+                className
+            )}
+        >
+            <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                <p className="text-foreground/45 text-xs font-semibold tracking-[0.12em] uppercase">
+                    Part {position} of {series.parts.length}
+                </p>
+                <p className="text-foreground/55 text-xs">Series</p>
+            </div>
+            <h2 className="mt-1 text-base font-bold sm:text-lg">
+                {series.name}
+            </h2>
+            <ol className="mt-4 space-y-1">
+                {series.parts.map((part, index) => {
+                    const stepLabel = (
+                        <>
+                            <span
+                                aria-hidden
+                                className={cn(
+                                    'flex size-6 flex-none items-center justify-center rounded-full text-xs font-semibold',
+                                    part.isCurrent
+                                        ? 'bg-linear-to-br from-[var(--accent-from)] to-[var(--accent-to)] text-white'
+                                        : 'border-foreground/15 text-foreground/55 border'
+                                )}
+                            >
+                                {index + 1}
+                            </span>
+                            <span className="leading-snug">{part.title}</span>
+                        </>
+                    );
+
+                    return (
+                        <li key={part.slug}>
+                            {part.isCurrent ? (
+                                <span
+                                    aria-current="page"
+                                    className="text-foreground flex items-center gap-3 rounded-lg px-2 py-1.5 text-sm font-semibold"
+                                >
+                                    {stepLabel}
+                                </span>
+                            ) : (
+                                <Link
+                                    href={`/articles/${part.slug}`}
+                                    className="text-foreground/65 hover:bg-foreground/[0.04] hover:text-foreground flex items-center gap-3 rounded-lg px-2 py-1.5 text-sm transition-colors"
+                                >
+                                    {stepLabel}
+                                </Link>
+                            )}
+                        </li>
+                    );
+                })}
+            </ol>
+        </section>
+    );
+}

--- a/src/components/pages/articles/TableOfContents/MobileTableOfContents.tsx
+++ b/src/components/pages/articles/TableOfContents/MobileTableOfContents.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useMemo, useRef } from 'react';
+import ChevronIcon from '@/components/icons/chevron';
+import TocList from '@/components/pages/articles/TableOfContents/TocList';
+import { useScrollSpy } from '@/components/layout/Navbar/hooks/useScrollSpy';
+import { accentStyle } from '@/utils/accentStyle';
+import type { TocItem } from '@/lib/posts';
+
+/**
+ * Collapsible "On this page" disclosure shown above the body on small screens,
+ * where there is no room for a sticky sidebar. Closes itself once a heading is
+ * picked so the reader lands straight on the section.
+ */
+export default function MobileTableOfContents({
+    toc,
+    accentColors,
+}: {
+    toc: TocItem[];
+    accentColors: readonly [string, string];
+}) {
+    const ids = useMemo(() => toc.map((item) => item.id), [toc]);
+    const activeId = useScrollSpy(ids);
+    const detailsRef = useRef<HTMLDetailsElement>(null);
+
+    if (toc.length === 0) return null;
+
+    return (
+        <details
+            ref={detailsRef}
+            style={accentStyle(accentColors)}
+            className="border-foreground/10 bg-foreground/[0.02] group mb-8 rounded-xl border lg:hidden"
+        >
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold [&::-webkit-details-marker]:hidden">
+                <span className="text-foreground/45 text-xs tracking-[0.12em] uppercase">
+                    On this page
+                </span>
+                <ChevronIcon className="text-foreground/50 size-4 transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="px-3 pb-3">
+                <TocList
+                    toc={toc}
+                    activeId={activeId}
+                    onNavigate={() => detailsRef.current?.removeAttribute('open')}
+                />
+            </div>
+        </details>
+    );
+}

--- a/src/components/pages/articles/TableOfContents/TocList.tsx
+++ b/src/components/pages/articles/TableOfContents/TocList.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/utils/cn';
+import type { TocItem } from '@/lib/posts';
+
+/**
+ * The shared list of heading links behind both the desktop sidebar and the
+ * mobile disclosure. The active heading (tracked by scroll position) gets the
+ * article's accent colour and a filled marker; nested H3s are indented under
+ * their H2.
+ */
+export default function TocList({
+    toc,
+    activeId,
+    onNavigate,
+}: {
+    toc: TocItem[];
+    activeId: string | null;
+    onNavigate?: () => void;
+}) {
+    return (
+        <ul className="space-y-1 text-sm">
+            {toc.map((item) => {
+                const isActive = item.id === activeId;
+                return (
+                    <li key={item.id}>
+                        <a
+                            href={`#${item.id}`}
+                            onClick={onNavigate}
+                            aria-current={isActive ? 'location' : undefined}
+                            className={cn(
+                                'group flex items-center gap-2 rounded-md py-1 leading-snug transition-colors',
+                                item.level === 3 ? 'pl-5' : 'pl-2',
+                                isActive
+                                    ? 'text-[var(--accent-to)]'
+                                    : 'text-foreground/55 hover:text-foreground'
+                            )}
+                        >
+                            <span
+                                aria-hidden
+                                className={cn(
+                                    'h-1 w-1 flex-none rounded-full transition-all',
+                                    isActive
+                                        ? 'scale-125 bg-[var(--accent-to)]'
+                                        : 'bg-foreground/25 group-hover:bg-foreground/50'
+                                )}
+                            />
+                            <span className="min-w-0">{item.text}</span>
+                        </a>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/src/components/pages/articles/TableOfContents/index.tsx
+++ b/src/components/pages/articles/TableOfContents/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useMemo } from 'react';
+import TocList from '@/components/pages/articles/TableOfContents/TocList';
+import { useScrollSpy } from '@/components/layout/Navbar/hooks/useScrollSpy';
+import { accentStyle } from '@/utils/accentStyle';
+import type { TocItem } from '@/lib/posts';
+
+/**
+ * Desktop "On this page" navigator that sticks beside the article and highlights
+ * the heading currently in view. Hidden below `lg`, where
+ * MobileTableOfContents takes over. Tinted with the article's cover accent.
+ */
+export default function TableOfContents({
+    toc,
+    accentColors,
+}: {
+    toc: TocItem[];
+    accentColors: readonly [string, string];
+}) {
+    const ids = useMemo(() => toc.map((item) => item.id), [toc]);
+    const activeId = useScrollSpy(ids);
+
+    if (toc.length === 0) return null;
+
+    return (
+        <nav
+            aria-label="Table of contents"
+            style={accentStyle(accentColors)}
+            className="sticky top-24 hidden max-h-[calc(100vh-8rem)] overflow-y-auto lg:block"
+        >
+            <p className="text-foreground/45 mb-3 text-xs font-semibold tracking-[0.12em] uppercase">
+                On this page
+            </p>
+            <TocList
+                toc={toc}
+                activeId={activeId}
+            />
+        </nav>
+    );
+}

--- a/src/components/pages/articles/TechStack.tsx
+++ b/src/components/pages/articles/TechStack.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/utils/cn';
+
+/**
+ * The concrete tools an article builds on, shown as a labelled strip of
+ * monospace chips. Distinct from tags (which are clickable topic filters): these
+ * are non-interactive stack markers that tell the reader what they will be
+ * working with.
+ */
+export default function TechStack({
+    tech,
+    className,
+}: {
+    tech: string[];
+    className?: string;
+}) {
+    if (tech.length === 0) return null;
+
+    return (
+        <div className={cn('flex flex-wrap items-center gap-2', className)}>
+            <span className="text-foreground/45 text-xs font-semibold tracking-[0.1em] uppercase">
+                Stack
+            </span>
+            <ul className="flex flex-wrap gap-2">
+                {tech.map((item) => (
+                    <li
+                        key={item}
+                        className="border-foreground/10 bg-foreground/[0.03] text-foreground/75 rounded-md border px-2 py-0.5 font-mono text-xs"
+                    >
+                        {item}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/pages/articles/WhatYoullLearn.tsx
+++ b/src/components/pages/articles/WhatYoullLearn.tsx
@@ -1,0 +1,56 @@
+import CheckIcon from '@/components/icons/check';
+import { accentStyle } from '@/utils/accentStyle';
+import { cn } from '@/utils/cn';
+
+/**
+ * A boxed summary of the key takeaways, drawn from the article's `learn`
+ * frontmatter, so a reader can decide in seconds whether the piece is for them.
+ * The card and its check marks pick up the article's cover accent.
+ */
+export default function WhatYoullLearn({
+    items,
+    accentColors,
+    className,
+}: {
+    items: string[];
+    accentColors: readonly [string, string];
+    className?: string;
+}) {
+    if (items.length === 0) return null;
+
+    return (
+        <section
+            aria-labelledby="what-youll-learn"
+            style={accentStyle(accentColors)}
+            className={cn(
+                'border-foreground/10 relative overflow-hidden rounded-2xl border p-6 sm:p-8',
+                className
+            )}
+        >
+            {/* A faint accent wash bleeds in from the leading edge of the card. */}
+            <span
+                aria-hidden
+                className="pointer-events-none absolute inset-y-0 left-0 w-1 bg-linear-to-b from-[var(--accent-from)] to-[var(--accent-to)]"
+            />
+            <h2
+                id="what-youll-learn"
+                className="text-foreground/45 text-xs font-semibold tracking-[0.12em] uppercase"
+            >
+                What you&rsquo;ll learn
+            </h2>
+            <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+                {items.map((item) => (
+                    <li
+                        key={item}
+                        className="flex items-start gap-3"
+                    >
+                        <CheckIcon className="mt-0.5 size-4 flex-none text-[var(--accent-to)]" />
+                        <span className="text-foreground/80 text-sm leading-relaxed">
+                            {item}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/pages/articles/hooks/useModalChrome.ts
+++ b/src/components/pages/articles/hooks/useModalChrome.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * The shared chrome behind the article overlays (Mermaid full view, image
+ * lightbox): on mount it locks body scroll, moves focus to `initialFocusRef`,
+ * and closes on Escape; on unmount it restores scroll and returns focus to
+ * whatever was focused before. The effect runs once for the overlay's lifetime,
+ * `onClose` is read through a ref so a fresh callback identity each render never
+ * re-captures the previously focused element (which would break focus return).
+ */
+export function useModalChrome<T extends HTMLElement>(
+    onClose: () => void,
+    initialFocusRef?: RefObject<T | null>
+): void {
+    const onCloseRef = useRef(onClose);
+    onCloseRef.current = onClose;
+
+    useEffect(() => {
+        const previouslyFocused = document.activeElement as HTMLElement | null;
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        initialFocusRef?.current?.focus();
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onCloseRef.current();
+        };
+        document.addEventListener('keydown', onKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+            document.body.style.overflow = previousOverflow;
+            previouslyFocused?.focus?.();
+        };
+    }, [initialFocusRef]);
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -18,6 +18,15 @@ const PUBLIC_DIRECTORY = path.join(process.cwd(), 'public');
 /** How many articles are listed per page on the /articles index. */
 export const ARTICLES_PER_PAGE = 9;
 
+/** A self-rated difficulty, surfaced as a badge on the article header. */
+export type ArticleDifficulty = 'Beginner' | 'Intermediate' | 'Advanced';
+
+/** One article's place in a multi-part series, declared in its frontmatter. */
+interface SeriesFrontmatter {
+    name: string;
+    order: number;
+}
+
 interface Frontmatter {
     title?: string;
     description?: string;
@@ -26,6 +35,36 @@ interface Frontmatter {
     tags?: string[];
     draft?: boolean;
     cover?: string;
+    /** A single grouping label (broader than tags) used to rank related posts. */
+    category?: string;
+    difficulty?: ArticleDifficulty;
+    /** Concrete tools/stack the article builds on, shown as a stack strip. */
+    tech?: string[];
+    /** Key takeaways rendered in the "What you'll learn" card. */
+    learn?: string[];
+    series?: SeriesFrontmatter;
+}
+
+/** A heading in the article body, used to build the table of contents. */
+export interface TocItem {
+    id: string;
+    text: string;
+    /** Heading level: 2 for `##`, 3 for `###`. */
+    level: number;
+}
+
+/** One entry in a series tracker, in reading order. */
+export interface SeriesPart {
+    slug: string;
+    title: string;
+    order: number;
+    isCurrent: boolean;
+}
+
+/** A resolved series: its name plus every published part, in reading order. */
+export interface ArticleSeries {
+    name: string;
+    parts: SeriesPart[];
 }
 
 export interface ArticleSummary {
@@ -39,10 +78,19 @@ export interface ArticleSummary {
     /** The cover's two dominant colours, used to tint the card to match it. */
     coverColors: readonly [string, string];
     readingMinutes: number;
+    category?: string;
+    difficulty?: ArticleDifficulty;
+    series?: SeriesFrontmatter;
 }
 
 export interface Article extends ArticleSummary {
     html: string;
+    /** Body headings (H2/H3) for the table of contents. */
+    toc: TocItem[];
+    /** Key takeaways for the "What you'll learn" card; empty when unset. */
+    learn: string[];
+    /** Stack/tools the article uses; empty when unset. */
+    tech: string[];
 }
 
 interface ParsedArticle {
@@ -51,9 +99,19 @@ interface ParsedArticle {
     content: string;
 }
 
+// A static build renders every article page, and each page reads the full
+// corpus several times (getArticle + related + series + adjacent). Parsing all
+// files once and caching the result avoids re-reading every markdown file on
+// each call. Only cached in production builds so that editing an article in dev
+// still shows up on the next request without restarting the server.
+let parsedFilesCache: ParsedArticle[] | null = null;
+
 function readArticleFiles(): ParsedArticle[] {
+    if (parsedFilesCache && process.env.NODE_ENV === 'production') {
+        return parsedFilesCache;
+    }
     if (!fs.existsSync(ARTICLES_DIRECTORY)) return [];
-    return fs
+    const files = fs
         .readdirSync(ARTICLES_DIRECTORY)
         .filter((name) => name.endsWith('.md') || name.endsWith('.mdx'))
         .map((name) => {
@@ -68,6 +126,8 @@ function readArticleFiles(): ParsedArticle[] {
             const { data, content } = matter(raw);
             return { slug, data: data as Frontmatter, content };
         });
+    parsedFilesCache = files;
+    return files;
 }
 
 function estimateReadingMinutes(content: string): number {
@@ -113,6 +173,12 @@ function toSummary(article: ParsedArticle): ArticleSummary {
         cover,
         coverColors: resolveCoverColors(cover, slug),
         readingMinutes: estimateReadingMinutes(content),
+        category: data.category,
+        difficulty: data.difficulty,
+        series:
+            data.series && typeof data.series.name === 'string'
+                ? { name: data.series.name, order: Number(data.series.order) || 0 }
+                : undefined,
     };
 }
 
@@ -319,29 +385,161 @@ marked.use({
     },
 });
 
+/** Turn heading text into a URL-safe anchor slug (`Cache-aside` -> `cache-aside`). */
+function slugifyHeading(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+};
+
+/** Strip inline tags and decode the few entities `marked` emits, for plain text. */
+function headingPlainText(inner: string): string {
+    return inner
+        .replace(/<[^>]+>/g, '')
+        .replace(/&amp;|&lt;|&gt;|&quot;|&#39;/g, (entity) => HTML_ENTITIES[entity])
+        // Drop any other entity (e.g. &hellip;, &#8230;) so it never leaks a
+        // literal "hellip" into the slug; the visible heading keeps its glyph.
+        .replace(/&#?[a-z0-9]+;/gi, '')
+        .trim();
+}
+
+/**
+ * Adds stable `id` anchors to the body's H2/H3 headings and returns the table of
+ * contents alongside the rewritten HTML. IDs and the TOC are produced in a single
+ * pass so they always agree; duplicate slugs are disambiguated with a numeric
+ * suffix (`-2`, `-3`). Headings that already carry an id are left untouched.
+ */
+function addHeadingIdsAndExtractToc(html: string): {
+    html: string;
+    toc: TocItem[];
+} {
+    const toc: TocItem[] = [];
+    const used = new Map<string, number>();
+    const rewritten = html.replace(
+        /<h([23])>([\s\S]*?)<\/h\1>/g,
+        (match, level: string, inner: string) => {
+            const text = headingPlainText(inner);
+            if (!text) return match;
+            const base = slugifyHeading(text) || 'section';
+            const seen = used.get(base) ?? 0;
+            used.set(base, seen + 1);
+            const id = seen === 0 ? base : `${base}-${seen + 1}`;
+            toc.push({ id, text, level: Number(level) });
+            return `<h${level} id="${id}">${inner}</h${level}>`;
+        }
+    );
+    return { html: rewritten, toc };
+}
+
+/** A self-contained list of takeaways/tools from frontmatter, never null. */
+function stringList(value: unknown): string[] {
+    return Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === 'string')
+        : [];
+}
+
 /** A single rendered article, or null if the slug is missing or a draft. */
 export async function getArticle(slug: string): Promise<Article | null> {
     const article = readArticleFiles().find((item) => item.slug === slug);
     if (!article || article.data.draft === true) return null;
-    const html = await marked.parse(article.content);
-    return { ...toSummary(article), html };
+    const rendered = await marked.parse(article.content);
+    const { html, toc } = addHeadingIdsAndExtractToc(rendered);
+    return {
+        ...toSummary(article),
+        html,
+        toc,
+        learn: stringList(article.data.learn),
+        tech: stringList(article.data.tech),
+    };
 }
 
-/** Up to `limit` other articles, ranked by shared tags then recency. */
+/**
+ * Up to `limit` other articles ranked by relevance to `slug`: each shared tag
+ * counts most, a shared category and a shared series add a strong signal, and
+ * recency breaks ties so the suggestion list never feels stale. Articles with no
+ * signal at all are dropped rather than padded with arbitrary posts.
+ */
 export function getRelatedArticles(slug: string, limit = 3): ArticleSummary[] {
     const all = getAllArticles();
     const current = all.find((article) => article.slug === slug);
     if (!current) return [];
     const currentTags = new Set(current.tags);
+
     return all
         .filter((article) => article.slug !== slug)
-        .map((article) => ({
-            article,
-            shared: article.tags.filter((tag) => currentTags.has(tag)).length,
-        }))
-        .sort((a, b) => b.shared - a.shared)
+        .map((article) => {
+            const sharedTags = article.tags.filter((tag) =>
+                currentTags.has(tag)
+            ).length;
+            const sameCategory =
+                current.category && article.category === current.category;
+            const sameSeries =
+                current.series && article.series?.name === current.series.name;
+            const score =
+                sharedTags * 3 +
+                (sameCategory ? 4 : 0) +
+                (sameSeries ? 5 : 0);
+            return { article, score };
+        })
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) =>
+            b.score !== a.score
+                ? b.score - a.score
+                : a.article.date < b.article.date
+                  ? 1
+                  : -1
+        )
         .slice(0, limit)
         .map((entry) => entry.article);
+}
+
+/**
+ * The series `slug` belongs to, with every published part in reading order, or
+ * null when the article is standalone or the series has only this one part.
+ */
+export function getSeriesForArticle(slug: string): ArticleSeries | null {
+    const all = getAllArticles();
+    const current = all.find((article) => article.slug === slug);
+    if (!current?.series) return null;
+    const seriesName = current.series.name;
+    const parts = all
+        .filter((article) => article.series?.name === seriesName)
+        .sort((a, b) => (a.series?.order ?? 0) - (b.series?.order ?? 0))
+        .map((article) => ({
+            slug: article.slug,
+            title: article.title,
+            order: article.series?.order ?? 0,
+            isCurrent: article.slug === slug,
+        }));
+    if (parts.length < 2) return null;
+    return { name: seriesName, parts };
+}
+
+/**
+ * The articles published just before and after `slug` in the chronological feed,
+ * for previous/next navigation. `previous` is the older neighbour, `next` the
+ * newer one; either is undefined at the ends of the list.
+ */
+export function getAdjacentArticles(slug: string): {
+    previous?: ArticleSummary;
+    next?: ArticleSummary;
+} {
+    const all = getAllArticles(); // newest first
+    const index = all.findIndex((article) => article.slug === slug);
+    if (index === -1) return {};
+    return {
+        next: index > 0 ? all[index - 1] : undefined,
+        previous: index < all.length - 1 ? all[index + 1] : undefined,
+    };
 }
 
 /** Every tag used across published articles, sorted alphabetically. */

--- a/src/utils/accentStyle.ts
+++ b/src/utils/accentStyle.ts
@@ -1,0 +1,16 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * Exposes an article's two cover-accent colours as the `--accent-from` /
+ * `--accent-to` custom properties, so themed article UI (reading bar, TOC,
+ * series tracker, "what you'll learn") can pick up the page's colour identity
+ * with a single `style={accentStyle(article.coverColors)}`.
+ */
+export function accentStyle(
+    accentColors: readonly [string, string]
+): CSSProperties {
+    return {
+        '--accent-from': accentColors[0],
+        '--accent-to': accentColors[1],
+    } as CSSProperties;
+}

--- a/src/utils/articleJsonLd.ts
+++ b/src/utils/articleJsonLd.ts
@@ -4,6 +4,8 @@ import type { Article } from '@/lib/posts';
 
 export function buildArticleJsonLd(article: Article): WithContext<BlogPosting> {
     const url = `${siteURL}/articles/${article.slug}`;
+    // Tags plus the concrete stack make a richer keyword set than tags alone.
+    const keywords = [...article.tags, ...article.tech];
     return {
         '@context': 'https://schema.org',
         '@type': 'BlogPosting',
@@ -14,6 +16,8 @@ export function buildArticleJsonLd(article: Article): WithContext<BlogPosting> {
         datePublished: article.date,
         dateModified: article.updated ?? article.date,
         image: article.cover ? `${siteURL}${article.cover}` : siteThumbnail,
+        ...(keywords.length > 0 && { keywords: keywords.join(', ') }),
+        ...(article.category && { articleSection: article.category }),
         author: {
             '@type': 'Person',
             '@id': `${siteURL}#person`,


### PR DESCRIPTION
Build out the article reading experience (issue #97) with features that degrade gracefully, so existing posts render unchanged unless they opt in via frontmatter.

- Reading progress bar tied to the article's cover accent
- Auto-generated table of contents: sticky sidebar on desktop, collapsible on mobile, with scrollspy; H2/H3 headings get stable anchor ids
- Rich metadata: difficulty badge, "updated" stamp, and a stack strip
- "What you'll learn" takeaways card from frontmatter
- Click-to-zoom image lightbox with keyboard navigation
- Previous/next chronological navigation
- Multi-part series tracker
- Related articles scored by tags, category, and series with a recency tiebreak

Add frontmatter fields (category, difficulty, tech, learn, series) parsed in posts.ts, enrich sample articles to exercise them, and extend the BlogPosting JSON-LD with keywords and articleSection.

Share modal chrome (scroll lock, focus return, Escape) via useModalChrome, reused by the lightbox and Mermaid full view, and factor the accent CSS variables into accentStyle. Memoize article file parsing in production builds.