### PR TITLE
feat: add system/light/dark theme switcher

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,62 @@
 @import 'tailwindcss';
 @plugin "@tailwindcss/typography";
 
+/* Make the `dark:` utility variant follow the theme switcher instead of only the
+   OS. Two branches, mirroring the token rules below: the resolved theme written
+   to <html data-theme> (ThemeScript/theme.ts), and a prefers-color-scheme
+   fallback that applies only when no theme has been resolved (JavaScript off).
+   With JS, data-theme is always the resolved light/dark (system included), so the
+   attribute branch covers everything and the media branch is the no-JS path.
+   Tailwind wraps each branch in :where(), so utility specificity is preserved. */
+@custom-variant dark {
+    &:where([data-theme='dark'], [data-theme='dark'] *) {
+        @slot;
+    }
+    @media (prefers-color-scheme: dark) {
+        &:where(:root:not([data-theme]), :root:not([data-theme]) *) {
+            @slot;
+        }
+    }
+}
+
+/* Theme tokens. The light palette is the default; the dark palette is applied by
+   the switcher writing the resolved theme to <html data-theme="dark"> (inline,
+   via ThemeScript/theme.ts), and by the OS media query as a no-JS fallback. The
+   dark rule is intentionally NOT expressed with light-dark(): the CSS compiler
+   lowers light-dark() to a prefers-color-scheme polyfill that ignores the
+   color-scheme property, so a forced choice would not take effect. color-scheme
+   is still set (following the OS by default) so native controls and the inline
+   light-dark() brand colours in SkillsArea resolve to the active theme; the
+   switcher overrides it inline on <html>. See src/components/layout/ThemeToggle. */
 :root {
+    color-scheme: light dark;
     --background: #ededed;
     --foreground: #171717;
     --section-swell-indigo: #e9e9f0;
     --section-swell-blue: #e7ebf2;
     --section-swell-yellow: #f0eee4;
     --section-swell-teal: #e6f1ef;
+}
+
+/* Applied when the OS prefers dark and the user has not overridden (no
+   data-theme, e.g. JavaScript disabled), or when the resolved theme is dark. */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) {
+        --background: #0a0a0a;
+        --foreground: #ededed;
+        --section-swell-indigo: #0d0c16;
+        --section-swell-blue: #0a0d17;
+        --section-swell-yellow: #11100a;
+        --section-swell-teal: #0a1413;
+    }
+}
+:root[data-theme='dark'] {
+    --background: #0a0a0a;
+    --foreground: #ededed;
+    --section-swell-indigo: #0d0c16;
+    --section-swell-blue: #0a0d17;
+    --section-swell-yellow: #11100a;
+    --section-swell-teal: #0a1413;
 }
 
 @theme inline {
@@ -29,17 +78,6 @@
     --text-box-edge-text-alphabetic: text alphabetic;
     --text-box-edge-cap-alphabetic: cap alphabetic;
     --text-box-edge-ex-text: ex text;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #0a0a0a;
-        --foreground: #ededed;
-        --section-swell-indigo: #0d0c16;
-        --section-swell-blue: #0a0d17;
-        --section-swell-yellow: #11100a;
-        --section-swell-teal: #0a1413;
-    }
 }
 
 body {
@@ -76,23 +114,27 @@ body {
    transparent" band and lets the gradient meet the footer seamlessly in both
    light and dark mode. */
 .page-gradient {
+    --wash-strength: 6%;
     background-image: linear-gradient(
         180deg,
-        color-mix(in oklab, var(--page-grad-from) 6%, var(--background)) 0%,
-        color-mix(in oklab, var(--page-grad-to) 6%, var(--background)) 50%,
+        color-mix(in oklab, var(--page-grad-from) var(--wash-strength), var(--background))
+            0%,
+        color-mix(in oklab, var(--page-grad-to) var(--wash-strength), var(--background))
+            50%,
         var(--background) 100%
     );
 }
 
+/* A touch stronger when the resolved theme is dark; only the mix strength
+   changes, so the single gradient rule above is reused. Mirrored on the OS media
+   query for the no-JS fallback (no data-theme set). */
 @media (prefers-color-scheme: dark) {
-    .page-gradient {
-        background-image: linear-gradient(
-            180deg,
-            color-mix(in oklab, var(--page-grad-from) 12%, var(--background)) 0%,
-            color-mix(in oklab, var(--page-grad-to) 12%, var(--background)) 50%,
-            var(--background) 100%
-        );
+    :root:not([data-theme]) .page-gradient {
+        --wash-strength: 12%;
     }
+}
+:root[data-theme='dark'] .page-gradient {
+    --wash-strength: 12%;
 }
 
 /* Cross-fade the wash on route change: the element persists across client

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/config/constants';
 import { GoogleTagManager } from '@next/third-parties/google';
 import { JsonLdScript } from '@/components/seo/JsonLdScript';
+import { ThemeScript } from '@/components/layout/ThemeToggle/ThemeScript';
 import HashScroll from '@/components/layout/HashScroll';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
@@ -103,8 +104,12 @@ export default function RootLayout({
         <html
             lang="en"
             className="scroll-smooth"
+            suppressHydrationWarning
         >
             <head>
+                {/* Applies the saved theme before first paint (no flash). Must be
+                    first in <head> and runs in every environment. */}
+                <ThemeScript />
                 <meta
                     name="apple-mobile-web-app-title"
                     content={siteName}

--- a/src/components/icons/monitor.tsx
+++ b/src/components/icons/monitor.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/utils/cn';
+
+export default function Monitor({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            className={cn('', className)}
+            {...rest}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <rect
+                x="2"
+                y="4"
+                width="20"
+                height="14"
+                rx="2"
+            />
+            <path d="M8 22h8M12 18v4" />
+        </svg>
+    );
+}

--- a/src/components/icons/moon.tsx
+++ b/src/components/icons/moon.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/utils/cn';
+
+export default function Moon({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            className={cn('', className)}
+            {...rest}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+    );
+}

--- a/src/components/icons/sun.tsx
+++ b/src/components/icons/sun.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/utils/cn';
+
+export default function Sun({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            className={cn('', className)}
+            {...rest}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <circle
+                cx="12"
+                cy="12"
+                r="4"
+            />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+    );
+}

--- a/src/components/layout/Footer/SignatureSpotlight/SignatureSpotlight.module.css
+++ b/src/components/layout/Footer/SignatureSpotlight/SignatureSpotlight.module.css
@@ -18,10 +18,15 @@
     --spotlight-color: #a3a3a3; /* neutral-400 (light): one step up from the neutral-300 base */
 }
 
+/* neutral-600 (dark): one step up from the neutral-900 base. Applied via the OS
+   media query (no-JS fallback) and the resolved data-theme (the switcher). */
 @media (prefers-color-scheme: dark) {
-    .spotlight {
-        --spotlight-color: #525252; /* neutral-600 (dark): one step up from the neutral-900 base */
+    :global(html:not([data-theme])) .spotlight {
+        --spotlight-color: #525252;
     }
+}
+:global(html[data-theme='dark']) .spotlight {
+    --spotlight-color: #525252;
 }
 
 .reveal {

--- a/src/components/layout/Navbar/MobileMenuPanel.tsx
+++ b/src/components/layout/Navbar/MobileMenuPanel.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/utils/cn';
 import NavItem from '@/components/layout/Navbar/NavItem';
 import NavLogo from '@/components/layout/Navbar/NavLogo';
+import ThemeToggle from '@/components/layout/ThemeToggle';
 import type { NavItemData } from '@/components/layout/Navbar/contents';
 
 interface MobileMenuPanelProps {
@@ -27,7 +28,11 @@ export default function MobileMenuPanel({
         <nav
             aria-label="Primary"
             className={cn(
-                'border-foreground/10 bg-background/70 absolute top-full right-0 mt-2 w-56 origin-top-right rounded-2xl border p-2 shadow-xl shadow-black/10 backdrop-blur-lg transition-all duration-200 ease-out',
+                // Cap the height to the space below the button so a long list
+                // (sections + pages + studio + theme) scrolls within the panel
+                // instead of running off short screens; dvh tracks the mobile
+                // browser chrome, overscroll-contain stops scroll chaining.
+                'border-foreground/10 bg-background/70 absolute top-full right-0 mt-2 max-h-[calc(100dvh-5.5rem)] w-56 origin-top-right overflow-y-auto overscroll-contain rounded-2xl border p-2 shadow-xl shadow-black/10 backdrop-blur-lg transition-all duration-200 ease-out',
                 open
                     ? 'visible scale-100 opacity-100'
                     : 'pointer-events-none invisible scale-95 opacity-0'
@@ -102,6 +107,14 @@ export default function MobileMenuPanel({
                     </ul>
                 </>
             )}
+            <div
+                aria-hidden="true"
+                className="bg-foreground/10 my-1 h-px"
+            />
+            <div className="flex items-center justify-between px-4 py-2">
+                <span className="text-foreground/60 text-sm">Theme</span>
+                <ThemeToggle />
+            </div>
         </nav>
     );
 }

--- a/src/components/layout/Navbar/index.tsx
+++ b/src/components/layout/Navbar/index.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { isDevelopment } from '@/config/env';
 import DesktopNav from '@/components/layout/Navbar/DesktopNav';
 import MobileNav from '@/components/layout/Navbar/MobileNav';
+import ThemeMenu from '@/components/layout/ThemeToggle/ThemeMenu';
 import {
     articlesItem,
     heroId,
@@ -62,6 +63,7 @@ export default function Navbar({
                 studioItems={studio}
                 isActive={isActive}
             />
+            <ThemeMenu />
         </>
     );
 }

--- a/src/components/layout/ThemeToggle/ThemeMenu.tsx
+++ b/src/components/layout/ThemeToggle/ThemeMenu.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useRef } from 'react';
+import { cn } from '@/utils/cn';
+import { useTheme } from '@/components/layout/ThemeToggle/hooks/useTheme';
+import { themeOptions } from '@/components/layout/ThemeToggle/options';
+import { useDisclosure } from '@/components/layout/Navbar/hooks/useDisclosure';
+import { useCloseOnEscape } from '@/components/layout/Navbar/hooks/useCloseOnEscape';
+import { useCloseOnClickOutside } from '@/components/layout/Navbar/hooks/useCloseOnClickOutside';
+import { useCloseOnRouteChange } from '@/components/layout/Navbar/hooks/useCloseOnRouteChange';
+
+/**
+ * Desktop theme control: a round icon button fixed to the top-right that opens a
+ * small menu of the three preferences (light / system / dark). The trigger shows
+ * the current preference's icon. Hidden on mobile, where the segmented
+ * ThemeToggle lives inside the menu panel instead.
+ */
+export default function ThemeMenu() {
+    const { preference, setPreference } = useTheme();
+    const { open, toggle, close } = useDisclosure();
+    const menuRef = useRef<HTMLDivElement>(null);
+    useCloseOnEscape(open, close);
+    useCloseOnClickOutside(menuRef, open, close);
+    useCloseOnRouteChange(close);
+
+    const ActiveIcon =
+        themeOptions.find((option) => option.value === preference)?.Icon ??
+        themeOptions[0].Icon;
+
+    return (
+        <div
+            ref={menuRef}
+            className="fixed top-4 right-4 z-50 hidden md:block"
+        >
+            <button
+                type="button"
+                onClick={toggle}
+                aria-haspopup="menu"
+                aria-expanded={open}
+                aria-label="Theme"
+                title="Theme"
+                className="border-foreground/10 bg-background/60 text-foreground/80 hover:text-foreground relative flex size-11 cursor-pointer items-center justify-center rounded-full border shadow-lg shadow-black/5 backdrop-blur-lg transition-colors"
+            >
+                <ActiveIcon
+                    aria-hidden="true"
+                    className="size-5"
+                />
+            </button>
+            <div
+                className={cn(
+                    'absolute top-full right-0 mt-2',
+                    open ? '' : 'pointer-events-none'
+                )}
+            >
+                <div
+                    role="menu"
+                    aria-label="Theme"
+                    className={cn(
+                        'border-foreground/10 bg-background/70 w-44 origin-top-right rounded-2xl border p-2 shadow-xl shadow-black/10 backdrop-blur-lg transition-all duration-200 ease-out',
+                        open
+                            ? 'visible scale-100 opacity-100'
+                            : 'invisible scale-95 opacity-0'
+                    )}
+                >
+                    <ul className="flex flex-col gap-0.5">
+                        {themeOptions.map(({ value, label, Icon }) => {
+                            const active = preference === value;
+                            return (
+                                <li
+                                    key={value}
+                                    role="none"
+                                >
+                                    <button
+                                        type="button"
+                                        role="menuitemradio"
+                                        aria-checked={active}
+                                        onClick={() => {
+                                            setPreference(value);
+                                            close();
+                                        }}
+                                        className={cn(
+                                            'flex w-full cursor-pointer items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-colors',
+                                            active
+                                                ? 'bg-foreground/10 text-foreground font-semibold'
+                                                : 'text-foreground/70 hover:text-foreground hover:bg-foreground/5'
+                                        )}
+                                    >
+                                        <Icon
+                                            aria-hidden="true"
+                                            className="size-4"
+                                        />
+                                        {label}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/layout/ThemeToggle/ThemeScript.tsx
+++ b/src/components/layout/ThemeToggle/ThemeScript.tsx
@@ -1,0 +1,14 @@
+import { THEME_STORAGE_KEY } from '@/components/layout/ThemeToggle/theme';
+
+// Applies the persisted theme to <html> before the first paint, so a saved
+// light/dark choice never flashes the wrong theme on load. This mirrors
+// resolvePreference/applyPreference in theme.ts and must stay in sync with them.
+// It is intentionally tiny and dependency-free (it is inlined and blocks the
+// first paint) and is NOT gated on NODE_ENV, since it must run in dev too.
+const script = `(function(){try{var p=localStorage.getItem(${JSON.stringify(
+    THEME_STORAGE_KEY
+)});var t=(p==='light'||p==='dark')?p:(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');var d=document.documentElement;d.setAttribute('data-theme',t);d.style.colorScheme=t;}catch(e){}})();`;
+
+export function ThemeScript() {
+    return <script dangerouslySetInnerHTML={{ __html: script }} />;
+}

--- a/src/components/layout/ThemeToggle/hooks/useTheme.ts
+++ b/src/components/layout/ThemeToggle/hooks/useTheme.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+    applyPreference,
+    getStoredPreference,
+    notifyPreferenceChange,
+    storePreference,
+    subscribe,
+    type ThemePreference,
+} from '@/components/layout/ThemeToggle/theme';
+
+/**
+ * Reads and updates the theme preference, keeping every mounted instance and the
+ * <html> element in sync. SSR and the first client render both start at 'system'
+ * so the markup matches; the stored value is read after mount to avoid a
+ * hydration mismatch (the pre-paint ThemeScript has already applied it to the DOM).
+ */
+export function useTheme() {
+    const [preference, setPreferenceState] = useState<ThemePreference>('system');
+
+    useEffect(() => {
+        setPreferenceState(getStoredPreference());
+        // Re-sync on a preference change (this or another instance), a cross-tab
+        // storage write, or an OS scheme flip while on 'system'.
+        const sync = () => {
+            const next = getStoredPreference();
+            setPreferenceState(next);
+            applyPreference(next);
+        };
+        return subscribe(sync);
+    }, []);
+
+    const setPreference = (next: ThemePreference) => {
+        setPreferenceState(next);
+        storePreference(next);
+        applyPreference(next);
+        notifyPreferenceChange();
+    };
+
+    return { preference, setPreference };
+}

--- a/src/components/layout/ThemeToggle/index.tsx
+++ b/src/components/layout/ThemeToggle/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+import { useTheme } from '@/components/layout/ThemeToggle/hooks/useTheme';
+import { themeOptions } from '@/components/layout/ThemeToggle/options';
+
+/**
+ * Segmented three-icon control for the theme preference (light / system / dark).
+ * Used in the mobile menu panel; the wrapper's background/spacing is left to the
+ * caller via `className`.
+ */
+export default function ThemeToggle({ className }: { className?: string }) {
+    const { preference, setPreference } = useTheme();
+
+    return (
+        <div
+            role="group"
+            aria-label="Theme"
+            className={cn('flex items-center gap-0.5', className)}
+        >
+            {themeOptions.map(({ value, label, Icon }) => {
+                const active = preference === value;
+                return (
+                    <button
+                        key={value}
+                        type="button"
+                        onClick={() => setPreference(value)}
+                        aria-pressed={active}
+                        aria-label={`${label} theme`}
+                        title={`${label} theme`}
+                        className={cn(
+                            'flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors',
+                            active
+                                ? 'bg-foreground/10 text-foreground'
+                                : 'text-foreground/60 hover:text-foreground'
+                        )}
+                    >
+                        <Icon
+                            aria-hidden="true"
+                            className="size-4"
+                        />
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/components/layout/ThemeToggle/options.ts
+++ b/src/components/layout/ThemeToggle/options.ts
@@ -1,0 +1,18 @@
+import Sun from '@/components/icons/sun';
+import Monitor from '@/components/icons/monitor';
+import Moon from '@/components/icons/moon';
+import type { ThemePreference } from '@/components/layout/ThemeToggle/theme';
+
+export interface ThemeOption {
+    value: ThemePreference;
+    label: string;
+    Icon: (props: React.SVGProps<SVGSVGElement>) => React.ReactElement;
+}
+
+/** The three theme choices, shared by the segmented ThemeToggle (mobile) and the
+ *  round ThemeMenu (desktop). Ordered system -> light -> dark. */
+export const themeOptions: ThemeOption[] = [
+    { value: 'system', label: 'System', Icon: Monitor },
+    { value: 'light', label: 'Light', Icon: Sun },
+    { value: 'dark', label: 'Dark', Icon: Moon },
+];

--- a/src/components/layout/ThemeToggle/theme.ts
+++ b/src/components/layout/ThemeToggle/theme.ts
@@ -1,0 +1,102 @@
+// Theme core: the single source of truth for the light/dark/system preference.
+// Framework-agnostic and SSR-safe (every window/document/localStorage access is
+// guarded), so it can be shared by the React hook, the pre-paint ThemeScript,
+// and the Mermaid renderer without pulling any of them into each other.
+//
+// The stored value is the user's *preference* ('system' | 'light' | 'dark').
+// What we write to <html> is the *resolved* theme ('light' | 'dark'): data-theme
+// drives the attribute selectors and style.color-scheme drives every light-dark()
+// token. Keeping the resolved theme on the element (never "system") means CSS
+// only ever deals with a concrete light or dark, so no @media duplication.
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'theme';
+
+// Fired on window when the preference changes in this tab, so every mounted
+// consumer (both navbar toggles, the Mermaid renderer) re-reads it in sync.
+const THEME_CHANGE_EVENT = 'themepreferencechange';
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+function isPreference(value: unknown): value is ThemePreference {
+    return value === 'system' || value === 'light' || value === 'dark';
+}
+
+export function getStoredPreference(): ThemePreference {
+    if (typeof window === 'undefined') return 'system';
+    try {
+        const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+        return isPreference(stored) ? stored : 'system';
+    } catch {
+        return 'system';
+    }
+}
+
+export function storePreference(preference: ThemePreference): void {
+    try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, preference);
+    } catch {
+        // Ignore write failures (private mode, storage disabled).
+    }
+}
+
+function prefersDark(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        window.matchMedia(DARK_QUERY).matches
+    );
+}
+
+export function resolvePreference(preference: ThemePreference): ResolvedTheme {
+    if (preference === 'light' || preference === 'dark') return preference;
+    return prefersDark() ? 'dark' : 'light';
+}
+
+/**
+ * Writes the resolved theme to <html> so the CSS can react. Mirrors the inline
+ * pre-paint script in ThemeScript; the two must stay aligned.
+ */
+export function applyPreference(preference: ThemePreference): void {
+    if (typeof document === 'undefined') return;
+    const resolved = resolvePreference(preference);
+    const root = document.documentElement;
+    root.dataset.theme = resolved;
+    root.style.colorScheme = resolved;
+}
+
+export function getResolvedTheme(): ResolvedTheme {
+    if (typeof document !== 'undefined') {
+        const current = document.documentElement.dataset.theme;
+        if (current === 'light' || current === 'dark') return current;
+    }
+    return prefersDark() ? 'dark' : 'light';
+}
+
+/** Broadcasts an in-tab preference change so every consumer re-reads it. */
+export function notifyPreferenceChange(): void {
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+    }
+}
+
+/**
+ * Subscribes to anything that can change the resolved theme: an in-tab
+ * preference change, a cross-tab storage write, or an OS scheme flip (which only
+ * matters while the preference is 'system'). Returns an unsubscribe function.
+ */
+export function subscribe(listener: () => void): () => void {
+    if (typeof window === 'undefined') return () => {};
+    const media = window.matchMedia(DARK_QUERY);
+    const onStorage = (event: StorageEvent) => {
+        if (event.key === THEME_STORAGE_KEY) listener();
+    };
+    window.addEventListener(THEME_CHANGE_EVENT, listener);
+    window.addEventListener('storage', onStorage);
+    media.addEventListener('change', listener);
+    return () => {
+        window.removeEventListener(THEME_CHANGE_EVENT, listener);
+        window.removeEventListener('storage', onStorage);
+        media.removeEventListener('change', listener);
+    };
+}

--- a/src/components/pages/articles/ArticleCard/ArticleCard.module.css
+++ b/src/components/pages/articles/ArticleCard/ArticleCard.module.css
@@ -11,13 +11,16 @@
     --tint-strength: 8%;
 }
 
+/* A translucent colour over near-black reads much dimmer than over the light
+   background, so dark mode needs a higher mix to stay visible while still feeling
+   soft. Mirrored on the OS media query for the no-JS fallback. */
 @media (prefers-color-scheme: dark) {
-    .card {
-        /* A translucent colour over near-black reads much dimmer than over the
-           light background, so dark mode needs a higher mix to stay visible
-           while still feeling soft. */
+    :global(html:not([data-theme])) .card {
         --tint-strength: 14%;
     }
+}
+:global(html[data-theme='dark']) .card {
+    --tint-strength: 14%;
 }
 
 .card::before {

--- a/src/components/pages/articles/ArticleContent/ArticleContent.module.css
+++ b/src/components/pages/articles/ArticleContent/ArticleContent.module.css
@@ -13,8 +13,9 @@
 }
 
 /* Shiki code blocks. Shiki emits per-token --shiki-light / --shiki-dark custom
-   properties; we apply the light palette by default and the dark palette under
-   prefers-color-scheme so code matches the site theme in both modes. */
+   properties; the light palette is applied by default and the dark palette when
+   the resolved theme is dark (data-theme, set by the switcher) or, without JS,
+   when the OS prefers dark. See globals.css for why light-dark() is avoided. */
 .content :global(.shiki) {
     background-color: var(--shiki-light-bg);
 }
@@ -75,17 +76,30 @@
     white-space: nowrap;
     color: color-mix(in srgb, var(--foreground) 80%, transparent);
 }
+
+/* Dark Shiki palette: the OS media query is the no-JS fallback; the resolved
+   data-theme is what the switcher drives. */
 @media (prefers-color-scheme: dark) {
-    .content :global(.shiki) {
+    :global(html:not([data-theme])) .content :global(.shiki) {
         background-color: var(--shiki-dark-bg);
     }
-    .content :global(.shiki),
-    .content :global(.shiki) span {
+    :global(html:not([data-theme])) .content :global(.shiki),
+    :global(html:not([data-theme])) .content :global(.shiki) span {
         color: var(--shiki-dark);
     }
-    .content :global(.code-block) {
+    :global(html:not([data-theme])) .content :global(.code-block) {
         background-color: var(--shiki-dark-bg);
     }
+}
+:global(html[data-theme='dark']) .content :global(.shiki) {
+    background-color: var(--shiki-dark-bg);
+}
+:global(html[data-theme='dark']) .content :global(.shiki),
+:global(html[data-theme='dark']) .content :global(.shiki) span {
+    color: var(--shiki-dark);
+}
+:global(html[data-theme='dark']) .content :global(.code-block) {
+    background-color: var(--shiki-dark-bg);
 }
 
 /* Embedded GitHub gists. GitHub's gist-embed stylesheet references Primer
@@ -118,82 +132,83 @@
 }
 
 /* GitHub's gist-embed stylesheet ships only a light palette (chrome via tokens,
-   syntax via hardcoded github-light hex). In dark mode we repaint the gist with
-   GitHub's github-dark colors so it matches the site theme. Selectors are kept
-   specific enough to win over GitHub's linked stylesheet. */
-@media (prefers-color-scheme: dark) {
-    .content :global(.gist-embed .gist-file) {
-        border-color: #30363d;
-    }
-    .content :global(.gist-embed .gist-data) {
-        background-color: #0d1117;
-        border-bottom-color: #30363d;
-    }
-    .content :global(.gist-embed .highlight) {
-        background: #0d1117;
-    }
-    .content :global(.gist-embed .blob-num) {
-        color: #6e7681;
-        background-color: #0d1117;
-    }
-    .content :global(.gist-embed .blob-code-inner) {
-        color: #e6edf3;
-    }
-    .content :global(.gist-embed .gist-meta) {
-        background-color: #161b22;
-    }
-    .content :global(.gist-embed .gist-meta a) {
-        color: #8b949e;
-    }
+   syntax via hardcoded github-light hex). When the resolved theme is dark we
+   repaint the gist with GitHub's github-dark colors so it matches the site theme.
+   Selectors are kept specific enough to win over GitHub's linked stylesheet.
+   Unlike the other surfaces this keyed only on data-theme (not also the OS media
+   query): the ~30 selectors are not worth duplicating for the rare no-JS case,
+   where the gist harmlessly stays in GitHub's readable light theme. */
+:global(html[data-theme='dark']) .content :global(.gist-embed .gist-file) {
+    border-color: #30363d;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .gist-data) {
+    background-color: #0d1117;
+    border-bottom-color: #30363d;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .highlight) {
+    background: #0d1117;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .blob-num) {
+    color: #6e7681;
+    background-color: #0d1117;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .blob-code-inner) {
+    color: #e6edf3;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .gist-meta) {
+    background-color: #161b22;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .gist-meta a) {
+    color: #8b949e;
+}
 
-    /* github-dark syntax palette (mirrors GitHub's grouped selectors) */
-    .content :global(.gist-embed .pl-c),
-    .content :global(.gist-embed .pl-ba) {
-        color: #8b949e;
-    }
-    .content :global(.gist-embed .pl-sg) {
-        color: #6e7681;
-    }
-    .content :global(.gist-embed .pl-k) {
-        color: #ff7b72;
-    }
-    .content :global(.gist-embed .pl-c1),
-    .content :global(.gist-embed .pl-s .pl-v),
-    .content :global(.gist-embed .pl-mh),
-    .content :global(.gist-embed .pl-ms) {
-        color: #79c0ff;
-    }
-    .content :global(.gist-embed .pl-e),
-    .content :global(.gist-embed .pl-en),
-    .content :global(.gist-embed .pl-mdr) {
-        color: #d2a8ff;
-    }
-    .content :global(.gist-embed .pl-ent),
-    .content :global(.gist-embed .pl-mi1) {
-        color: #7ee787;
-    }
-    .content :global(.gist-embed .pl-v),
-    .content :global(.gist-embed .pl-smw) {
-        color: #ffa657;
-    }
-    .content :global(.gist-embed .pl-s),
-    .content :global(.gist-embed .pl-pds),
-    .content :global(.gist-embed .pl-sr),
-    .content :global(.gist-embed .pl-sr .pl-sra),
-    .content :global(.gist-embed .pl-corl) {
-        color: #a5d6ff;
-    }
-    .content :global(.gist-embed .pl-smi),
-    .content :global(.gist-embed .pl-s .pl-s1) {
-        color: #c9d1d9;
-    }
-    .content :global(.gist-embed .pl-ml) {
-        color: #f2cc60;
-    }
-    .content :global(.gist-embed .pl-bu),
-    .content :global(.gist-embed .pl-md) {
-        color: #f85149;
-    }
+/* github-dark syntax palette (mirrors GitHub's grouped selectors) */
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-c),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-ba) {
+    color: #8b949e;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-sg) {
+    color: #6e7681;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-k) {
+    color: #ff7b72;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-c1),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-s .pl-v),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-mh),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-ms) {
+    color: #79c0ff;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-e),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-en),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-mdr) {
+    color: #d2a8ff;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-ent),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-mi1) {
+    color: #7ee787;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-v),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-smw) {
+    color: #ffa657;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-s),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-pds),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-sr),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-sr .pl-sra),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-corl) {
+    color: #a5d6ff;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-smi),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-s .pl-s1) {
+    color: #c9d1d9;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-ml) {
+    color: #f2cc60;
+}
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-bu),
+:global(html[data-theme='dark']) .content :global(.gist-embed .pl-md) {
+    color: #f85149;
 }
 
 /* Anchored headings sit clear of the floating navbar and the reading-progress
@@ -268,22 +283,39 @@
 .content :global(.markdown-alert-caution) {
     --alert-accent: #cf222e;
 }
+/* github-dark accents: OS media query is the no-JS fallback, data-theme is the
+   switcher-driven override. */
 @media (prefers-color-scheme: dark) {
-    .content :global(.markdown-alert-note) {
+    :global(html:not([data-theme])) .content :global(.markdown-alert-note) {
         --alert-accent: #4493f8;
     }
-    .content :global(.markdown-alert-tip) {
+    :global(html:not([data-theme])) .content :global(.markdown-alert-tip) {
         --alert-accent: #3fb950;
     }
-    .content :global(.markdown-alert-important) {
+    :global(html:not([data-theme])) .content :global(.markdown-alert-important) {
         --alert-accent: #ab7df8;
     }
-    .content :global(.markdown-alert-warning) {
+    :global(html:not([data-theme])) .content :global(.markdown-alert-warning) {
         --alert-accent: #d29922;
     }
-    .content :global(.markdown-alert-caution) {
+    :global(html:not([data-theme])) .content :global(.markdown-alert-caution) {
         --alert-accent: #f85149;
     }
+}
+:global(html[data-theme='dark']) .content :global(.markdown-alert-note) {
+    --alert-accent: #4493f8;
+}
+:global(html[data-theme='dark']) .content :global(.markdown-alert-tip) {
+    --alert-accent: #3fb950;
+}
+:global(html[data-theme='dark']) .content :global(.markdown-alert-important) {
+    --alert-accent: #ab7df8;
+}
+:global(html[data-theme='dark']) .content :global(.markdown-alert-warning) {
+    --alert-accent: #d29922;
+}
+:global(html[data-theme='dark']) .content :global(.markdown-alert-caution) {
+    --alert-accent: #f85149;
 }
 
 /* Tables. renderMarkdown wraps each <table> in a .table-scroll.not-prose div, so
@@ -355,9 +387,12 @@
     background-color: color-mix(in srgb, #f8e3a1 70%, transparent);
 }
 @media (prefers-color-scheme: dark) {
-    .content mark {
+    :global(html:not([data-theme])) .content mark {
         background-color: color-mix(in srgb, #d29922 40%, transparent);
     }
+}
+:global(html[data-theme='dark']) .content mark {
+    background-color: color-mix(in srgb, #d29922 40%, transparent);
 }
 
 /* Sub/superscript keep a stable line height so they do not disturb the leading. */

--- a/src/components/pages/articles/MermaidRenderer/hooks/useMermaidSvg.ts
+++ b/src/components/pages/articles/MermaidRenderer/hooks/useMermaidSvg.ts
@@ -1,12 +1,17 @@
 'use client';
 
 import { useEffect, useId, useState } from 'react';
+import {
+    getResolvedTheme,
+    subscribe,
+} from '@/components/layout/ThemeToggle/theme';
 
 /**
  * Renders Mermaid source to an SVG string on the client. Mermaid is imported
- * lazily (only when a diagram exists) and re-rendered when the system colour
- * scheme changes so the diagram matches the site theme. Returns '' until the
- * first render succeeds (or stays '' if the source fails to parse).
+ * lazily (only when a diagram exists) and re-rendered when the resolved theme
+ * changes (an OS scheme flip while on 'system', or a manual switch) so the
+ * diagram matches the site. Returns '' until the first render succeeds (or stays
+ * '' if the source fails to parse).
  */
 export function useMermaidSvg(source: string): string {
     const reactId = useId();
@@ -14,7 +19,6 @@ export function useMermaidSvg(source: string): string {
 
     useEffect(() => {
         const renderId = `mermaid-${reactId.replace(/[^a-zA-Z0-9]/g, '')}`;
-        const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
         let cancelled = false;
 
         async function render() {
@@ -23,7 +27,7 @@ export function useMermaidSvg(source: string): string {
                 if (cancelled) return;
                 mermaid.initialize({
                     startOnLoad: false,
-                    theme: darkScheme.matches ? 'dark' : 'default',
+                    theme: getResolvedTheme() === 'dark' ? 'dark' : 'default',
                 });
                 const result = await mermaid.render(renderId, source);
                 // Drop Mermaid's fixed max-width so pan/zoom can scale the SVG.
@@ -36,11 +40,10 @@ export function useMermaidSvg(source: string): string {
         }
 
         void render();
-        const onSchemeChange = () => void render();
-        darkScheme.addEventListener('change', onSchemeChange);
+        const unsubscribe = subscribe(() => void render());
         return () => {
             cancelled = true;
-            darkScheme.removeEventListener('change', onSchemeChange);
+            unsubscribe();
         };
     }, [source, reactId]);
 

--- a/src/components/pages/home/AboutMeArea/FacetCard.module.css
+++ b/src/components/pages/home/AboutMeArea/FacetCard.module.css
@@ -36,11 +36,18 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .glow {
+    :global(html:not([data-theme])) .glow {
         background: radial-gradient(
             120% 120% at var(--facet-origin),
             color-mix(in oklab, var(--facet-accent) 32%, transparent) 0%,
             transparent 64%
         );
     }
+}
+:global(html[data-theme='dark']) .glow {
+    background: radial-gradient(
+        120% 120% at var(--facet-origin),
+        color-mix(in oklab, var(--facet-accent) 32%, transparent) 0%,
+        transparent 64%
+    );
 }

--- a/src/components/pages/home/ProjectsArea/ProjectCard/ProjectCard.module.css
+++ b/src/components/pages/home/ProjectsArea/ProjectCard/ProjectCard.module.css
@@ -17,9 +17,12 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .card {
+    :global(html:not([data-theme])) .card {
         --glow-strength: 6%;
     }
+}
+:global(html[data-theme='dark']) .card {
+    --glow-strength: 6%;
 }
 
 .card::before {

--- a/src/components/pages/home/SkillsArea/SkillCard/SkillCard.module.css
+++ b/src/components/pages/home/SkillsArea/SkillCard/SkillCard.module.css
@@ -9,18 +9,20 @@
    component, so the negative z-index keeps the wash under the icon and name). It is
    tinted with the tile's --brand-color (set inline per tile) and falls back to
    --foreground for the monochrome logos; deliberately barely noticeable, with the
-   strength stepping up a touch in dark mode. color-scheme is set here (not globally)
-   so the per-theme light-dark() brand colours used on these tiles (JavaScript,
-   Linux) resolve to the system theme. */
+   strength stepping up a touch in dark mode. The per-theme light-dark() brand
+   colours used on these tiles (JavaScript, Linux) resolve against the color-scheme
+   set globally on <html> (see globals.css), so no local color-scheme is needed. */
 .tile {
-    @apply scheme-light-dark;
     --glow-strength: 8%;
 }
 
 @media (prefers-color-scheme: dark) {
-    .tile {
+    :global(html:not([data-theme])) .tile {
         --glow-strength: 14%;
     }
+}
+:global(html[data-theme='dark']) .tile {
+    --glow-strength: 14%;
 }
 
 .tile::before {


### PR DESCRIPTION
Add a persisted theme preference (system/light/dark), applied before first paint via an inline script to avoid a flash. Desktop gets a round icon button fixed top-right that opens a menu; mobile gets a segmented control in the menu panel. System follows the OS live and is the default.

Drive theming off a data-theme attribute holding the resolved theme, with the Tailwind dark variant re-pointed at it (@custom-variant dark) so dark: utilities follow the choice, and CSS custom-property tokens overridden by attribute selectors plus a prefers-color-scheme no-JS fallback. Avoid light-dark() in CSS files since the compiler lowers it to a media-query polyfill that ignores a forced color-scheme. Cap the mobile menu panel height so it scrolls when long.