### PR TITLE
feat: strengthen resume page SEO and structured data

### DIFF
--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -9,8 +9,15 @@ import {
     resumeName,
     resumeSections,
 } from '@/app/resume/contents';
+import { JsonLd } from '@/components/seo/JsonLd';
+import { resumeJsonLd } from '@/utils/resumeJsonLd';
 import { jetBrainsMono } from '@/config/monoFont';
-import { siteName, siteThumbnail } from '@/config/constants';
+import {
+    siteLocale,
+    siteName,
+    siteThumbnail,
+    twitterUsername,
+} from '@/config/constants';
 
 const description = `The professional resume of ${siteName}: work experience, projects, technical skills, and education, with a one-click Save as PDF.`;
 
@@ -22,6 +29,8 @@ export const metadata: Metadata = {
         title: `Resume | ${siteName}`,
         description,
         url: '/resume',
+        siteName,
+        locale: siteLocale,
         type: 'website',
         images: [
             {
@@ -36,6 +45,8 @@ export const metadata: Metadata = {
         card: 'summary_large_image',
         title: `Resume | ${siteName}`,
         description,
+        creator: twitterUsername,
+        siteId: twitterUsername,
         images: [siteThumbnail],
     },
 };
@@ -54,6 +65,9 @@ export default function ResumePage() {
                 'print:scheme-light print:[--background:#fff] print:[--foreground:#000]'
             )}
         >
+            {process.env.NODE_ENV === 'production' && (
+                <JsonLd data={resumeJsonLd} />
+            )}
             <div className="print:hidden">
                 <Breadcrumb />
             </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { siteURL } from '@/config/constants';
+import { siteThumbnail, siteURL } from '@/config/constants';
 import { articleOgImagePath } from '@/utils/generateArticleCover';
 import { getAllArticles } from '@/lib/posts';
 
@@ -34,6 +34,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
             lastModified: now,
             changeFrequency: 'monthly',
             priority: 0.7,
+            images: [siteThumbnail],
         },
     ];
 

--- a/src/utils/resumeJsonLd.ts
+++ b/src/utils/resumeJsonLd.ts
@@ -1,0 +1,83 @@
+import { WithContext, ProfilePage } from 'schema-dts';
+
+import {
+    addressCountry,
+    currentJobTitle,
+    currentWorkplace,
+    currentWorkplaceURL,
+    education,
+    educationURL,
+    facebookURL,
+    githubURL,
+    jsonLdAlternateName,
+    jsonLdDescription,
+    jsonLdKnowsAbout,
+    linkedInURL,
+    personFamilyName,
+    personGivenName,
+    siteAuthorEmail,
+    siteName,
+    siteThumbnail,
+    siteURL,
+    twitterURL,
+} from '@/config/constants';
+
+const resumeURL = `${siteURL}/resume`;
+
+// ProfilePage for the /resume route. It reuses the same Person `@id`
+// (`${siteURL}#person`) as the global home-page ProfilePage in `jsonLd.ts`, so
+// search engines treat both pages as describing one entity, and adds
+// resume-specific signals (`hasOccupation`, `worksFor`, `alumniOf`, `knowsAbout`)
+// that make the page eligible for richer person/resume results.
+export const resumeJsonLd: WithContext<ProfilePage> = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    url: resumeURL,
+    name: `Resume | ${siteName}`,
+    dateModified: new Date().toISOString(),
+    mainEntity: {
+        '@type': 'Person',
+        '@id': `${siteURL}#person`,
+        name: siteName,
+        givenName: personGivenName,
+        familyName: personFamilyName,
+        alternateName: jsonLdAlternateName,
+        url: siteURL,
+        image: siteThumbnail,
+        jobTitle: currentJobTitle,
+        description: jsonLdDescription,
+        address: {
+            '@type': 'PostalAddress',
+            addressCountry,
+        },
+        hasOccupation: {
+            '@type': 'Occupation',
+            name: currentJobTitle,
+            occupationLocation: {
+                '@type': 'Country',
+                name: addressCountry,
+            },
+            skills: jsonLdKnowsAbout,
+        },
+        worksFor: {
+            '@type': 'Organization',
+            '@id': `${currentWorkplaceURL}#org`,
+            name: currentWorkplace,
+            url: currentWorkplaceURL,
+        },
+        alumniOf: {
+            '@type': 'CollegeOrUniversity',
+            '@id': `${educationURL}#alumni`,
+            name: education,
+            url: educationURL,
+        },
+        knowsAbout: jsonLdKnowsAbout,
+        sameAs: [
+            linkedInURL,
+            githubURL,
+            facebookURL,
+            twitterURL,
+            `mailto:${siteAuthorEmail}`,
+        ],
+    },
+};


### PR DESCRIPTION
Restore og:site_name and og:locale on the resume OpenGraph card (previously dropped by the per-page shallow merge) and add twitter:creator/site. Emit a resume-scoped ProfilePage JSON-LD with hasOccupation, worksFor, alumniOf, and knowsAbout, reusing the shared Person @id so both pages describe one entity. Add the profile image to the resume sitemap entry.