### PR TITLE
fix: add og:site_name to shared page metadata

### DIFF
--- a/src/utils/pageMetadata.ts
+++ b/src/utils/pageMetadata.ts
@@ -40,6 +40,7 @@ export function buildPageMetadata({
             title: `${title} | ${siteName}`,
             description,
             url: path,
+            siteName,
             type: 'website',
             images: [
                 {


### PR DESCRIPTION
Pages using buildPageMetadata dropped og:site_name because their openGraph replaces the layout's wholesale, so cards rendered without the site name (e.g. Discord shows it above the title). Set siteName in the helper's openGraph.