### PR TITLE
feat: support multiple external links per project

### DIFF
--- a/src/components/pages/home/ProjectsArea/ProjectCard/index.tsx
+++ b/src/components/pages/home/ProjectsArea/ProjectCard/index.tsx
@@ -62,14 +62,15 @@ export default function ProjectCard({
                     ariaLabel={`${project.name} source on GitHub`}
                     Icon={GithubIcon}
                 />
-                {project.liveURL ? (
+                {project.links?.map((link) => (
                     <ProjectLink
-                        href={project.liveURL}
-                        label={project.liveLabel ?? 'Live'}
-                        ariaLabel={`${project.name}, ${project.liveLabel ?? 'Live'}`}
+                        key={link.url}
+                        href={link.url}
+                        label={link.label}
+                        ariaLabel={`${project.name}, ${link.label}`}
                         Icon={ExternalLinkIcon}
                     />
-                ) : null}
+                ))}
             </div>
         </li>
     );

--- a/src/components/pages/home/ProjectsArea/contents.ts
+++ b/src/components/pages/home/ProjectsArea/contents.ts
@@ -3,17 +3,21 @@
  *
  * NOTE: the descriptions below are concise, honest summaries inferred from the
  * repos. Refine the copy, and add real outcome metrics (downloads, installs,
- * stars, perf numbers) plus Marketplace/npm/demo links via `liveURL` where they
+ * stars, perf numbers) plus Marketplace/npm/demo links via `links` where they
  * exist. Do NOT add metrics you can't back up.
  */
+export type ProjectExternalLink = {
+    url: string;
+    label: string;
+};
+
 export type Project = {
     name: string;
     category: string;
     description: string;
     tech: string[];
     repoURL: string;
-    liveURL?: string;
-    liveLabel?: string;
+    links?: ProjectExternalLink[];
 };
 
 export const projects: Project[] = [
@@ -25,9 +29,16 @@ export const projects: Project[] = [
         tech: ['TypeScript', 'VS Code API'],
         repoURL:
             'https://github.com/shibbirweb/vs-code-extra-cursor-caret-height',
-        liveURL:
-            'https://marketplace.visualstudio.com/items?itemName=shibbirweb.extra-cursor-caret-height',
-        liveLabel: 'Marketplace',
+        links: [
+            {
+                url: 'https://marketplace.visualstudio.com/items?itemName=shibbirweb.extra-cursor-caret-height',
+                label: 'Marketplace',
+            },
+            {
+                url: 'https://open-vsx.org/extension/shibbirweb/extra-cursor-caret-height',
+                label: 'Open VSX',
+            },
+        ],
     },
     {
         name: 'CKEditor 5 Image Remove Callback',
@@ -37,9 +48,12 @@ export const projects: Project[] = [
         tech: ['JavaScript', 'CKEditor 5'],
         repoURL:
             'https://github.com/shibbirweb/ckeditor5-image-remove-event-callback-plugin',
-        liveURL:
-            'https://www.npmjs.com/package/ckeditor5-image-remove-event-callback-plugin',
-        liveLabel: 'npm',
+        links: [
+            {
+                url: 'https://www.npmjs.com/package/ckeditor5-image-remove-event-callback-plugin',
+                label: 'npm',
+            },
+        ],
     },
     {
         name: 'Advanced Laravel Vue Paginate',
@@ -49,9 +63,12 @@ export const projects: Project[] = [
         tech: ['Vue.js', 'JavaScript', 'Laravel'],
         repoURL:
             'https://github.com/shibbirweb/advanced-laravel-vue-paginate',
-        liveURL:
-            'https://www.npmjs.com/package/advanced-laravel-vue-paginate',
-        liveLabel: 'npm',
+        links: [
+            {
+                url: 'https://www.npmjs.com/package/advanced-laravel-vue-paginate',
+                label: 'npm',
+            },
+        ],
     },
     {
         name: 'Nginx Load Balancer',


### PR DESCRIPTION
Replace the single liveURL/liveLabel pair with a links array so a project can list any number of external links. Add the Open VSX registry link to the VS Code Caret Height extension alongside its Marketplace listing.