### PR TITLE
fix: stop service worker throwing no-response on third-party requests

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -2,19 +2,31 @@ schema: spec-driven
 
 # Project context (optional)
 # This is shown to AI when creating artifacts.
-# Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+context: |
+  Project: single-page personal portfolio for Shibbir Ahmed.
+  Stack: Next.js 15 (App Router), Tailwind CSS v4 (CSS-first, no tailwind.config.js),
+  TypeScript, pnpm 10, Node 22.
+  Deployment: statically exported (next.config.ts sets output: 'export') to ./out,
+  served on GitHub Pages under the custom domain https://shibbir.me. No runtime server:
+  no API routes, no Server Actions, no next/image optimizer, no middleware, no ISR.
+  Single source of truth for all personal data, URLs, and SEO keywords is
+  src/config/constants.ts; edit it first for any content change.
+  Imports always use the @/ alias, never relative paths. src/app/ holds routing only;
+  all components live in src/components/ grouped by purpose, and src/components/ must
+  never import from src/app/. src/utils/ is pure helper functions only. Use the cn()
+  helper for conditional classes. There is no test suite.
+  Copy rule: never use the em dash character anywhere; rephrase, or use a pipe for
+  title/name separators.
 
 # Per-artifact rules (optional)
-# Add custom rules for specific artifacts.
-# Example:
-#   rules:
-#     proposal:
-#       - Keep proposals under 500 words
-#       - Always include a "Non-goals" section
-#     tasks:
-#       - Break tasks into chunks of max 2 hours
+rules:
+  proposal:
+    - Never use the em dash character; rephrase, or use a pipe for separators.
+    - Call out static-export impact when a proposal touches rendering or data (no server runtime).
+  tasks:
+    - Reference concrete file paths under src/; prefer editing src/config/constants.ts for content changes.
+    - Do not introduce runtime server features (API routes, Server Actions, middleware, ISR); they break the static export.
+  spec:
+    - Keep components small and single-responsibility; section data lives in contents.ts, not inline.
+    - Respect Tailwind v4 CSS-first styling and co-located CSS Modules; there is no tailwind.config.js.
+    - Inside a CSS Module, prefer Tailwind via @apply for any declaration expressible as a utility (add @reference "tailwindcss"; at the top); only @apply classes/utilities Tailwind actually provides. Reach for raw CSS solely for what Tailwind cannot express (color-mix(), gradients, @keyframes bodies, bespoke custom properties).

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -13,6 +13,16 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope;
 
+// Serwist's stock defaultCache ends with two greedy rules: a NetworkFirst that
+// caches every cross-origin response and a NetworkOnly wildcard. When a
+// third-party script GTM injects (e.g. the Facebook pixel) is blocked or
+// offline, that NetworkFirst finds no cached fallback and rejects the fetch
+// event with `no-response`, surfacing as an uncaught SW error. Drop both
+// catch-alls (they are the last two entries) so third-party requests fall
+// through to the browser; caching them is pointless for a static site, and
+// same-origin pages/assets plus Google Fonts keep their specific rules above.
+const runtimeCaching = defaultCache.slice(0, -2);
+
 // The static offline shell (public/offline.html) is already in the Serwist
 // precache manifest (it is a public asset), so it is available to serve as the
 // navigation fallback below. It is a plain static file rather than a Next route
@@ -26,7 +36,7 @@ const serwist = new Serwist({
     skipWaiting: false,
     clientsClaim: true,
     navigationPreload: true,
-    runtimeCaching: defaultCache,
+    runtimeCaching,
     // When an unvisited page is opened offline, serve the precached
     // /offline.html shell instead of the browser's default error page.
     fallbacks: {


### PR DESCRIPTION
Serwist's stock defaultCache ends with a NetworkFirst that routes every cross-origin request plus a NetworkOnly wildcard. When a GTM-injected third-party script (e.g. the Facebook pixel) is blocked or offline, that NetworkFirst finds no cached fallback and rejects with `no-response`, surfacing as an uncaught SW error. Drop both catch-alls (defaultCache.slice(0, -2)) so third-party requests fall through to the browser; same-origin routes, Google Fonts, and the offline fallback are unchanged.

Also add OpenSpec project context and per-artifact rules in openspec/config.yaml.