### PR TITLE
feat: redesign PWA update toast as compact sticky card

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -142,14 +142,19 @@ export default function RootLayout({
                     <div className="print:hidden">
                         <Navbar hasArticles={hasArticles()} />
                     </div>
-                    <div className="flex grow flex-col">{children}</div>
+                    {/* ServiceWorkerManager is the last child so its sticky
+                        update toast floats over content while scrolling, then
+                        parks at this wrapper's bottom edge (top of the footer),
+                        clear of the footer signature below. Prod only (same gate
+                        as GTM/JSON-LD); a service worker would fight turbopack
+                        HMR in dev. */}
+                    <div className="flex grow flex-col">
+                        {children}
+                        {process.env.NODE_ENV === 'production' && (
+                            <ServiceWorkerManager />
+                        )}
+                    </div>
                     <Footer />
-                    {/* Service worker registration + update toast, prod only
-                        (same gate as GTM/JSON-LD); a service worker would fight
-                        turbopack HMR in dev. */}
-                    {process.env.NODE_ENV === 'production' && (
-                        <ServiceWorkerManager />
-                    )}
                 </PageGradientProvider>
             </body>
         </html>

--- a/src/components/pwa/UpdateToast/UpdateToast.module.css
+++ b/src/components/pwa/UpdateToast/UpdateToast.module.css
@@ -1,3 +1,17 @@
+/* Faint accent wash so the toast echoes the page gradient instead of reading as
+   a flat panel. Reuses the same --section-swell-* accents the homepage sections
+   use (defined for both themes at :root in globals.css), so it stays subtle and
+   flips light/dark automatically. Mixed toward transparent, not an opaque fill,
+   so the backdrop-blur still frosts the content behind it. A raw color-mix
+   gradient is one of the few values Tailwind cannot express, so it lives here. */
+.toast {
+    background-image: linear-gradient(
+        135deg,
+        color-mix(in oklab, var(--section-swell-blue) 82%, transparent) 0%,
+        color-mix(in oklab, var(--section-swell-teal) 82%, transparent) 100%
+    );
+}
+
 /* Entrance for the update toast: it eases up from below the viewport edge.
    Written as a raw @keyframes (a body Tailwind cannot express) and referenced
    from the same module so CSS Modules scopes the name and its use together.

--- a/src/components/pwa/UpdateToast/index.tsx
+++ b/src/components/pwa/UpdateToast/index.tsx
@@ -11,10 +11,10 @@ interface UpdateToastProps {
 }
 
 /**
- * Non-blocking notification that a newer build is ready. Inverts the theme
- * colours (background/foreground flip with the theme) so it reads as a distinct
- * surface in both light and dark, and sits above the footer without covering
- * page content.
+ * Non-blocking notification that a newer build is ready. A compact translucent
+ * card anchored to the bottom-right corner (matching the site's surface motif:
+ * blurred background, hairline border), so it stays out of the way of page
+ * content instead of spanning the viewport.
  */
 export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
     return (
@@ -23,18 +23,20 @@ export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
             aria-live="polite"
             className={cn(
                 styles.toast,
-                'bg-foreground text-background fixed inset-x-4 bottom-4 z-50 flex items-center gap-3 rounded-full px-4 py-3 shadow-lg sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2'
+                'border-foreground/10 sticky bottom-4 z-50 mx-4 flex max-w-[calc(100%-2rem)] items-center gap-3 self-center rounded-xl sm:self-start border py-2.5 pr-2.5 pl-3.5 shadow-lg backdrop-blur-lg'
             )}
         >
             <span
                 aria-hidden
-                className="bg-background/60 size-2 shrink-0 animate-pulse rounded-full"
+                className="bg-foreground/40 size-1.5 shrink-0 animate-pulse rounded-full"
             />
-            <p className="text-sm font-medium">New version available</p>
+            <p className="text-sm font-medium whitespace-nowrap">
+                Update available
+            </p>
             <button
                 type="button"
                 onClick={onReload}
-                className="bg-background text-foreground ml-1 rounded-full px-3 py-1 text-sm font-semibold transition-transform duration-200 hover:scale-105"
+                className="bg-foreground text-background hover:bg-foreground/90 ml-1 cursor-pointer rounded-lg px-3 py-1 text-xs font-semibold transition-colors"
             >
                 Reload
             </button>
@@ -42,7 +44,7 @@ export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
                 type="button"
                 onClick={onDismiss}
                 aria-label="Dismiss"
-                className="text-background/70 hover:text-background text-lg leading-none transition-colors"
+                className="text-foreground/50 hover:bg-foreground/10 hover:text-foreground flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-lg leading-none transition-colors"
             >
                 &times;
             </button>


### PR DESCRIPTION
Reshape the update toast from a full-width inverted pill into a compact card that sticky-parks above the footer signature instead of overlaying page content or the footer logo.

- Move ServiceWorkerManager into the main content wrapper so the toast is sticky (bottom-4) and parks at the wrapper's bottom edge, clear of the footer signature below.
- Translucent surface with backdrop blur and a hairline border, matching the site's surface motif.
- Faint blue-to-teal wash reusing the --section-swell-* accents so it echoes the page gradient and flips light/dark automatically.
- Center below 640px, bottom-left above; add pointer cursor to buttons.