### PR TITLE
feat: track page_view and article_view on route changes

### DIFF
--- a/openspec/changes/add-pageview-analytics/.openspec.yaml
+++ b/openspec/changes/add-pageview-analytics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/add-pageview-analytics/design.md
+++ b/openspec/changes/add-pageview-analytics/design.md
@@ -1,0 +1,55 @@
+## Context
+
+GTM (`GTM-W4DC9Z6`) is injected once in `src/app/layout.tsx` via `@next/third-parties/google`'s `GoogleTagManager`, prod-gated. This app uses the App Router, so navigations between `/`, `/now`, `/uses`, `/resume`, `/articles`, `/articles/[slug]`, and `/articles/search` are client-side transitions with no full page load. The GTM snippet does not itself send GA4 hits, and nothing in the app pushes to `dataLayer` on navigation, so only the initial landing is measured. Articles are real dynamic routes rendered from local Markdown (`src/app/articles/[slug]/page.tsx`, `dynamicParams = false`, `generateStaticParams`), so they benefit from distinct tracking.
+
+Constraints: static export (no server runtime), imports via the `@/` alias, components live under `src/components/` grouped by purpose, side effects belong in named `useXxx` hooks colocated in a `hooks/` folder, never use the em dash character.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Emit a `page_view` `dataLayer` event on initial load and on every client route change, with `page_path` and `page_title`.
+- Emit a distinct `article_view` event on `/articles/<slug>` detail routes, with `article_slug` and `article_title`.
+- Keep production gating identical to the existing GTM render; no analytics in dev.
+- Document the GTM container setup that forwards these events to GA4 without double counting.
+
+**Non-Goals:**
+- No changes to the GTM container from code (container config is done in the GTM UI).
+- No new analytics vendor, no direct `gtag.js`, no GA4 measurement ID in the repo.
+- No tracking of query-string changes or in-page hash/section changes (path-level only).
+- No consent-banner / cookie-consent work (out of scope for this change).
+
+## Decisions
+
+**Client tracker component + hook.** Add `src/components/analytics/PageviewTracker/index.tsx`, a `'use client'` component that calls `usePageviewTracking()` and returns `null`. Side-effecting logic lives in `src/components/analytics/PageviewTracker/hooks/usePageviewTracking.ts`. Rationale: matches the project rule that effects live in named hooks and components read top-down; a new `analytics/` group is purpose-based, consistent with the group-by-purpose convention. Alternative considered: inline the effect in `layout.tsx`, rejected because `layout.tsx` is a server component and holds routing/metadata concerns, not client effects.
+
+**Track by `usePathname` only, not `useSearchParams`.** The hook depends on `usePathname()` from `next/navigation`. Rationale: `useSearchParams` in a statically exported app forces a Suspense boundary and adds complexity; path granularity is sufficient for page-visit tracking. Trade-off: query-param-only changes are not tracked (acceptable, none of the routes rely on that for a "visit").
+
+**Emit via `sendGTMEvent`.** Use `sendGTMEvent` from `@next/third-parties/google` (already a dependency) to push events. It initializes/queues on `window.dataLayer`, so pushes made before the GTM script finishes loading are preserved. Alternative considered: manual `window.dataLayer.push`, rejected to avoid duplicating the library's initialization and typing.
+
+**Fire on mount + on pathname change.** A single `useEffect` keyed on `pathname` fires once on mount (covering the initial landing `page_view`) and again on each change. `page_title` is read from `document.title` inside the effect so the freshly-navigated title is used. Article detection uses the regex `/^\/articles\/([^/]+)$/`; when it matches and the captured segment is not `search`, an `article_view` event is pushed in addition to `page_view`, with `article_slug` = the segment.
+
+**Prod gating in the layout.** `<PageviewTracker />` is rendered in `src/app/layout.tsx` wrapped in `process.env.NODE_ENV === 'production'`, mirroring the existing `GoogleTagManager` render. Rationale: no GTM exists in dev to receive events, and this keeps a single, consistent gate.
+
+## GTM container configuration (done in the GTM UI, not the repo)
+
+Repo code only pushes `dataLayer` events. To turn them into GA4 hits, configure container `GTM-W4DC9Z6`:
+
+1. **Data Layer Variables:** create `page_path`, `page_title`, `article_slug`, `article_title` (Variable type: Data Layer Variable, matching the pushed keys).
+2. **Triggers:** create two Custom Event triggers, one firing on event name `page_view`, one on `article_view`.
+3. **GA4 Configuration:** create or confirm a GA4 Configuration tag with the GA4 Measurement ID.
+4. **GA4 event tag `page_view`:** event name `page_view`, event parameters mapped from `page_path` / `page_title`, firing on the `page_view` Custom Event trigger.
+5. **GA4 event tag `article_view`:** event name `article_view`, parameters from `article_slug` / `article_title`, firing on the `article_view` trigger.
+6. **Avoid duplicate landing hit:** do not attach a GA4 page-view tag to GTM's built-in Page View trigger; rely solely on the custom `page_view` event so the landing route is counted once.
+7. **Verify + publish:** use GTM Preview to confirm both events fire, then publish the container.
+
+## Risks / Trade-offs
+
+- [Double counting the landing page if a GA4 tag also fires on GTM's built-in Page View trigger] → Documented step 6: forward only the custom `page_view` event to GA4.
+- [`document.title` may lag one render on client navigation, so an event could carry the previous title] → Reading `document.title` inside the pathname-keyed effect captures the value after the metadata update in practice; acceptable for analytics granularity. If it proves flaky, a follow-up can pass the title explicitly.
+- [Reserved article segments beyond `search` added later would be miscounted as `article_view`] → The check excludes `search` explicitly; any future reserved segment under `/articles/` must be added to the exclusion.
+- [No consent gating] → Out of scope; the existing GTM already loads unconditionally in production, so this change does not alter the consent posture.
+
+## Migration Plan
+
+- Additive change; no data migration. Deploy via the normal `master` -> GitHub Pages flow.
+- Rollback: remove the `<PageviewTracker />` mount (or the component); GTM reverts to landing-only behavior. GTM-side tags can be paused independently in the container.

--- a/openspec/changes/add-pageview-analytics/proposal.md
+++ b/openspec/changes/add-pageview-analytics/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Google Tag Manager (`GTM-W4DC9Z6`) loads once in the root layout, but this is a Next.js App Router app where navigation between routes happens client-side without a full page load. GTM does not auto-emit anything on client route changes and nothing in the app pushes to `dataLayer` on navigation, so only the first landing page is ever recorded. Analytics effectively behaves as "single page." We want every route visit recorded, and individual article pages recorded distinctly so article engagement can be segmented in GA.
+
+## What Changes
+
+- Add a client-side route-change tracker that pushes a `page_view` event to the GTM `dataLayer` on initial load and on every subsequent client navigation, carrying `page_path` and `page_title`.
+- On article detail routes (`/articles/<slug>`), additionally push a distinct `article_view` event carrying `article_slug` and `article_title`, so articles are measurable separately from ordinary pages.
+- Mount the tracker in the root layout, gated on `process.env.NODE_ENV === 'production'`, mirroring the existing GTM render so dev stays clean.
+- Document the required GTM container configuration (Data Layer Variables, Custom Event triggers, GA4 event tags) since forwarding these events to GA4 happens in the GTM UI, outside the repo.
+
+## Capabilities
+
+### New Capabilities
+- `analytics`: Client-side page-visit and article-view event tracking that emits GTM `dataLayer` events on every App Router route change.
+
+### Modified Capabilities
+<!-- None. No existing spec's requirements change. -->
+
+## Impact
+
+- Static-export impact: the tracker is a client component using `usePathname`; it emits events at runtime in the browser and does not affect the static pre-render or `generateStaticParams`. No server runtime is introduced.
+- New code: `src/components/analytics/PageviewTracker/` (component + `hooks/usePageviewTracking.ts`).
+- Modified code: `src/app/layout.tsx` (import + prod-gated mount).
+- Dependencies: reuses `sendGTMEvent` from `@next/third-parties/google` (already a dependency) and `usePathname` from `next/navigation`. No new packages.
+- Out-of-repo: GTM container `GTM-W4DC9Z6` must be configured to forward the new events to GA4; documented in design.md.

--- a/openspec/changes/add-pageview-analytics/specs/analytics/spec.md
+++ b/openspec/changes/add-pageview-analytics/specs/analytics/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Page-visit tracking on every route change
+
+The system SHALL push a `page_view` event to the GTM `dataLayer` on initial page load and on every subsequent client-side App Router navigation. The event MUST include `page_path` (the current pathname) and `page_title` (the document title at navigation time). Tracking SHALL be active only when `process.env.NODE_ENV === 'production'`, matching the existing GTM gate.
+
+#### Scenario: Landing on the site
+
+- **WHEN** a visitor first loads any route in production
+- **THEN** exactly one `page_view` event is pushed to `dataLayer` with `page_path` set to that route's pathname and `page_title` set to the document title
+
+#### Scenario: Client-side navigation between routes
+
+- **WHEN** a visitor navigates client-side from one route to another (e.g. `/` to `/now`)
+- **THEN** a new `page_view` event is pushed for the destination pathname without a full page reload
+
+#### Scenario: Development environment
+
+- **WHEN** the app runs with `NODE_ENV` other than `production`
+- **THEN** no analytics events are pushed and no tracker is mounted
+
+### Requirement: Distinct article-view tracking
+
+The system SHALL, in addition to the `page_view` event, push a distinct `article_view` event to the GTM `dataLayer` when the visited route is an individual article detail page (`/articles/<slug>`, a single path segment after `/articles/` that is not the reserved `search` segment). The `article_view` event MUST include `article_slug` (the URL slug) and `article_title` (the document title at navigation time).
+
+#### Scenario: Viewing an article
+
+- **WHEN** a visitor is on `/articles/<slug>` where `<slug>` is a single path segment and not `search`
+- **THEN** both a `page_view` event and a separate `article_view` event are pushed, the latter carrying `article_slug` and `article_title`
+
+#### Scenario: Article index and search are not article views
+
+- **WHEN** a visitor is on `/articles` or `/articles/search`
+- **THEN** a `page_view` event is pushed but no `article_view` event is pushed
+
+### Requirement: Events forwardable to GA4 without duplication
+
+The emitted `dataLayer` events SHALL be structured as custom events (named `page_view` and `article_view`) so that a GTM container can forward them to GA4 via Custom Event triggers. The design SHALL document the required GTM container configuration and SHALL avoid duplicate landing-page hits by not relying on GTM's built-in Page View trigger for the same measurement.
+
+#### Scenario: GTM forwards a page visit to GA4
+
+- **WHEN** the GTM container has a GA4 event tag bound to the `page_view` Custom Event trigger
+- **THEN** each `page_view` dataLayer push results in exactly one GA4 event, with no duplicate hit from GTM's built-in Page View trigger

--- a/openspec/changes/add-pageview-analytics/tasks.md
+++ b/openspec/changes/add-pageview-analytics/tasks.md
@@ -1,0 +1,18 @@
+## 1. Tracking hook
+
+- [x] 1.1 Create `src/components/analytics/PageviewTracker/hooks/usePageviewTracking.ts`: read `usePathname()` from `next/navigation`; in a `useEffect` keyed on `pathname`, push `{ event: 'page_view', page_path: pathname, page_title: document.title }` via `sendGTMEvent` from `@next/third-parties/google`.
+- [x] 1.2 In the same hook, detect article detail routes with `/^\/articles\/([^/]+)$/` where the captured segment is not `search`; when matched, additionally push `{ event: 'article_view', article_slug: <segment>, article_title: document.title }`.
+
+## 2. Tracker component
+
+- [x] 2.1 Create `src/components/analytics/PageviewTracker/index.tsx` as a `'use client'` component that calls `usePageviewTracking()` and returns `null`; import the hook via the `@/` alias.
+
+## 3. Wire into layout
+
+- [x] 3.1 In `src/app/layout.tsx`, import `PageviewTracker` via the `@/` alias and render `<PageviewTracker />` gated on `process.env.NODE_ENV === 'production'`, alongside the existing `GoogleTagManager` render.
+
+## 4. Verify
+
+- [x] 4.1 Run `pnpm lint` and `pnpm build` to confirm the static export succeeds with the new client component (no Suspense/`useSearchParams` errors). Also verified the article-detection regex against every route and confirmed `page_view` / `article_view` / `page_path` / `article_slug` ship in the compiled prod `layout` chunk.
+- [ ] 4.2 Serve the `./out` export and use GTM Preview mode to confirm a single `page_view` fires on initial load, a `page_view` fires on each client route change, and an `article_view` fires only on `/articles/<slug>` (not on `/articles` or `/articles/search`), with no duplicate landing hit. (Maintainer step: needs live GTM container in the browser.)
+- [ ] 4.3 Perform the GTM container configuration in the GTM UI per design.md (Data Layer Variables, Custom Event triggers, GA4 event tags), then publish. (Maintainer step: out-of-repo GTM UI.)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import {
     twitterUsername,
 } from '@/config/constants';
 import { GoogleTagManager } from '@next/third-parties/google';
+import PageviewTracker from '@/components/analytics/PageviewTracker';
 import { JsonLdScript } from '@/components/seo/JsonLdScript';
 import { ThemeScript } from '@/components/layout/ThemeToggle/ThemeScript';
 import HashScroll from '@/components/layout/HashScroll';
@@ -129,7 +130,10 @@ export default function RootLayout({
                 ) : null}
             </head>
             {process.env.NODE_ENV === 'production' && (
-                <GoogleTagManager gtmId={googleTagManagerId} />
+                <>
+                    <GoogleTagManager gtmId={googleTagManagerId} />
+                    <PageviewTracker />
+                </>
             )}
             <body
                 className={`${notoSans.variable} bg-background relative flex min-h-svh flex-col text-base antialiased print:bg-white!`}

--- a/src/components/analytics/PageviewTracker/hooks/usePageviewTracking.ts
+++ b/src/components/analytics/PageviewTracker/hooks/usePageviewTracking.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { sendGTMEvent } from '@next/third-parties/google';
+
+/** Matches an individual article detail route (`/articles/<slug>`), capturing the slug. */
+const articleDetailPattern = /^\/articles\/([^/]+)$/;
+
+/** Segments under `/articles/` that are routes, not article slugs. */
+const reservedArticleSegments = new Set(['search']);
+
+/**
+ * Pushes a `page_view` GTM event on initial load and on every client-side route
+ * change, plus a distinct `article_view` event when the route is an article
+ * detail page. Path-level only (no query string). GTM (and any downstream GA4
+ * tags) exist only in production, so mount this behind the same prod gate.
+ */
+export function usePageviewTracking() {
+    const pathname = usePathname();
+
+    useEffect(() => {
+        const pageTitle = document.title;
+
+        sendGTMEvent({
+            event: 'page_view',
+            page_path: pathname,
+            page_title: pageTitle,
+        });
+
+        const articleMatch = pathname.match(articleDetailPattern);
+        const articleSlug = articleMatch?.[1];
+
+        if (articleSlug && !reservedArticleSegments.has(articleSlug)) {
+            sendGTMEvent({
+                event: 'article_view',
+                article_slug: articleSlug,
+                article_title: pageTitle,
+            });
+        }
+    }, [pathname]);
+}

--- a/src/components/analytics/PageviewTracker/index.tsx
+++ b/src/components/analytics/PageviewTracker/index.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { usePageviewTracking } from '@/components/analytics/PageviewTracker/hooks/usePageviewTracking';
+
+/**
+ * Renders nothing. Emits GTM `page_view` (and `article_view` on article detail
+ * routes) events on each App Router navigation. Mount once, prod-gated, beside
+ * the GTM snippet in the root layout.
+ */
+export default function PageviewTracker() {
+    usePageviewTracking();
+    return null;
+}


### PR DESCRIPTION
GTM loaded once in the root layout, but App Router client navigations fired nothing, so only the landing page was ever measured. Add a prod-gated client tracker that pushes a page_view dataLayer event on mount and on every pathname change, plus a distinct article_view event (with slug and title) on /articles/<slug> detail routes so articles can be segmented separately in GA. Uses sendGTMEvent; path-level only, so no useSearchParams Suspense boundary is needed for the static export.