### PR TITLE
feat: add giscus comments to article pages

### DIFF
--- a/openspec/changes/add-giscus-comments/.openspec.yaml
+++ b/openspec/changes/add-giscus-comments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/add-giscus-comments/design.md
+++ b/openspec/changes/add-giscus-comments/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The site is a statically exported Next.js app (`output: 'export'`) served on GitHub Pages, so there is no server runtime to host or moderate comments. Article bodies are pre-rendered Markdown HTML (`Article.html`) injected by the server component `ArticleContent`, then progressively upgraded by client "island" components (`MermaidRenderer`, `CodeBlockCopy`, `ImageLightbox`, `ReadingProgress`, `TableOfContents`) that run in the browser after hydration.
+
+giscus fits this model: it is a client-only iframe widget loaded from `giscus.app/client.js` that stores comments in GitHub Discussions. It needs no server, no npm dependency, and no build step. The site already resolves an explicit theme to `<html data-theme>` and exposes `getResolvedTheme()` + `subscribe()` from `@/components/layout/ThemeToggle/theme`; `MermaidRenderer` already uses these to re-theme a third-party widget, giving a proven pattern to copy.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render a giscus comment thread under every `/articles/<slug>` page.
+- Map threads by URL `pathname` so no per-article wiring is needed.
+- Keep the giscus theme in lockstep with the site theme, live, without reload.
+- Keep all embed parameters in `src/config/constants.ts` (single source of truth).
+- Preserve the static export: no server runtime, no new npm dependency.
+
+**Non-Goals:**
+- No custom comment UI, moderation dashboard, or self-hosted storage (GitHub Discussions owns that).
+- No comments on the `/articles` index, tag pages, `/now`, `/uses`, or the home teaser.
+- No SSR/prerender of comments; the widget is client-only by nature.
+- No `NODE_ENV` gating; the widget renders in dev and prod (a confirmed decision), unlike GTM/JSON-LD/service worker.
+
+## Decisions
+
+### Client island component, injected via `useEffect`
+A new `'use client'` component `src/components/pages/articles/Comments/` renders an empty container `<div ref>`; a colocated `hooks/useGiscus.ts` performs the side effect (per project rule, effects live in a named `useXxx` hook). The hook builds a `<script src="https://giscus.app/client.js">` element, sets the `data-*` attributes, and appends it to the container ref, mirroring the recommended giscus embed. It clears the container on cleanup so React re-mounts (or fast-refresh) do not double-inject.
+
+Alternative considered: `next/script`. Rejected because the codebase deliberately avoids `next/script` (its `afterInteractive`/`lazyOnload` strategies do not behave the same under static export, and there is zero existing usage). The manual `useEffect` injection matches `MermaidRenderer`'s dynamic-import island approach and keeps behavior identical in dev and prod.
+
+### Mapping by `pathname`
+`data-mapping="pathname"` binds each thread to the article URL with no per-page term. Alternatives: `specific` term = `article.slug` (more explicit, survives URL restructures, but requires threading the slug through to the client component) and `og:title` (fragile: editing a title orphans the thread). `pathname` is the giscus default and the least-config option; article slugs/paths are already stable, so it is the right trade-off. This was confirmed with the maintainer.
+
+### Live theme sync via `postMessage`
+Initial `data-theme` comes from `getResolvedTheme()` (`dark` -> giscus `dark`, otherwise `light`). For live updates, `subscribe(listener)` fires on manual toggle, cross-tab change, and OS scheme flip; the listener posts `{ giscus: { setConfig: { theme } } }` to the giscus iframe (`container.querySelector('iframe.giscus-frame')?.contentWindow`, target origin `https://giscus.app`). This is exactly the initial-set + `subscribe`-reapply shape in `useMermaidSvg` (`:30`, `:43`), but giscus updates in place through `postMessage` rather than a re-render, so no reload is needed.
+
+### Config in `src/config/constants.ts`
+Add `giscusRepo`, `giscusRepoId`, `giscusCategory`, `giscusCategoryId` as `export const`s next to `googleTagManagerId` / `facebookPageId`. These are public embed values (they ship in the client HTML), so committing them is fine. `giscusRepoId` and `giscusCategoryId` are opaque node IDs that can only be obtained from https://giscus.app after enabling Discussions and installing the giscus GitHub App, so they start as empty-string placeholders with an explaining comment. The component reads all four from constants and never hardcodes them.
+
+### Placement
+`<Comments />` goes in the article content column (the `min-w-0` div) directly after `<ArticlePager />` in `ArticleView/index.tsx`, so comments sit at reading width below the body/nav and above the related-articles aside. `ArticleView` stays a server component; `<Comments>` is a client-island sibling of `MermaidRenderer` / `CodeBlockCopy` / `ImageLightbox`, so the dev editor's full-page preview renders it too.
+
+### Performance
+Use `data-loading="lazy"` so giscus fetches the iframe only as it scrolls into view, keeping it off the initial article render cost.
+
+## Risks / Trade-offs
+
+- Third-party runtime dependency on `giscus.app` and GitHub Discussions -> if either is down, the widget fails to load; the article itself is unaffected because comments are an isolated island appended after content.
+- Rendering in dev/prod means local comment submissions post to the real repo Discussions -> mitigation: reviewers avoid submitting from local dev; the pathname is the same string regardless of origin, so no separate test threads are created by merely loading.
+- Empty `giscusRepoId` / `giscusCategoryId` -> giscus renders a visible configuration error instead of a thread. Mitigation: the constants carry a comment pointing to https://giscus.app, and the tasks include a manual pre-req step; verification requires real IDs before the widget works.
+- Privacy: loads a cross-origin iframe and, once a reader signs in, their GitHub identity and comments live in the repo's Discussions. This is inherent to giscus and acceptable for a personal blog.
+- Static export unaffected: no API route, Server Action, middleware, or ISR is introduced; the only additions are client-side.

--- a/openspec/changes/add-giscus-comments/proposal.md
+++ b/openspec/changes/add-giscus-comments/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Article pages (`/articles/[slug]`) offer no way for readers to respond, ask questions, or react. Adding [giscus](https://giscus.app), a GitHub Discussions backed comment widget, gives each article a discussion thread with zero moderation infrastructure to run and no personal data stored outside GitHub.
+
+## What Changes
+
+- Add a new client-side comment widget under every article body, powered by giscus (a pure client-side iframe embed loaded from `giscus.app/client.js`).
+- Map each article to its GitHub Discussion by `pathname` (the `/articles/<slug>/` URL), so no per-article configuration is required.
+- Sync the giscus theme live to the site theme (light/dark) via the existing `ThemeToggle` `getResolvedTheme` + `subscribe` module, mirroring how `MermaidRenderer` re-themes.
+- Store the giscus embed parameters (`giscusRepo`, `giscusRepoId`, `giscusCategory`, `giscusCategoryId`) in `src/config/constants.ts` as the single source of truth; components read them, never hardcode them.
+- The widget renders in dev and production (not gated on `NODE_ENV`), so placement and theming can be verified locally.
+
+Static-export impact: none of this needs a server runtime. giscus is a client-only iframe loaded at view time, so it is fully compatible with `output: 'export'`. No API route, Server Action, middleware, or build-time data source is introduced.
+
+## Capabilities
+
+### New Capabilities
+- `article-comments`: reader discussion under each article, provided by an embedded giscus widget mapped by URL pathname, themed in sync with the site, and configured from `src/config/constants.ts`.
+
+### Modified Capabilities
+<!-- None. No existing spec's requirements change. -->
+
+## Impact
+
+- New config: `src/config/constants.ts` gains `giscusRepo`, `giscusRepoId`, `giscusCategory`, `giscusCategoryId`. `giscusRepoId` and `giscusCategoryId` are not guessable and must be generated at https://giscus.app after enabling GitHub Discussions and installing the giscus GitHub App.
+- New component: `src/components/pages/articles/Comments/` (a `'use client'` island plus a `hooks/useGiscus.ts`).
+- Modified: `src/components/pages/articles/ArticleView/index.tsx` renders `<Comments />` in the article content column, below `ArticlePager`.
+- Reuses: `src/components/layout/ThemeToggle/theme.ts` (`getResolvedTheme`, `subscribe`).
+- No new npm dependency (giscus loads its own script from its CDN). External runtime dependency on `giscus.app` and GitHub Discussions availability.
+- Privacy: the widget loads a third-party iframe from `giscus.app`; comment content and identity live in GitHub Discussions on the repo.

--- a/openspec/changes/add-giscus-comments/specs/article-comments/spec.md
+++ b/openspec/changes/add-giscus-comments/specs/article-comments/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Comment widget on article pages
+
+The system SHALL render a giscus comment widget on every single-article page (`/articles/<slug>`), placed below the article body and its previous/next pager and above the related-articles section. The widget SHALL load entirely on the client from `giscus.app/client.js` with no server runtime, keeping the static export intact.
+
+#### Scenario: Widget appears under an article
+
+- **WHEN** a reader opens any `/articles/<slug>` page
+- **THEN** a giscus comment section renders below the article content and pager, and above related articles, without requiring any server request to this site
+
+#### Scenario: Index and non-article pages excluded
+
+- **WHEN** a reader views the `/articles` index, a tag page, or any non-article route
+- **THEN** no giscus comment widget is rendered
+
+### Requirement: Discussion mapping by pathname
+
+The system SHALL map each article to its GitHub Discussion using giscus `pathname` mapping, so that a given article URL always resolves to the same discussion thread without per-article configuration.
+
+#### Scenario: Article maps to its own thread
+
+- **WHEN** the widget loads on `/articles/<slug>`
+- **THEN** giscus is configured with `data-mapping="pathname"` so comments are bound to that article's URL path and distinct articles get distinct threads
+
+### Requirement: Live theme synchronization
+
+The comment widget SHALL initialize with the site's currently resolved theme (light or dark) and SHALL update the giscus theme live when the site theme changes, without a page reload.
+
+#### Scenario: Initial theme matches the site
+
+- **WHEN** the widget first loads
+- **THEN** its `data-theme` is set from the resolved site theme (`getResolvedTheme()` in `@/components/layout/ThemeToggle/theme`), `dark` yielding the dark giscus theme and otherwise the light one
+
+#### Scenario: Theme toggle flips the widget
+
+- **WHEN** the reader changes the site theme (manual toggle, or an OS scheme change while on `system`)
+- **THEN** the widget receives a `postMessage` `setConfig` update and re-themes to match, with no reload
+
+### Requirement: Configuration from a single source of truth
+
+The giscus embed parameters SHALL be defined in `src/config/constants.ts` (`giscusRepo`, `giscusRepoId`, `giscusCategory`, `giscusCategoryId`) and read from there by the widget component. These values SHALL NOT be hardcoded in any component.
+
+#### Scenario: Component reads config from constants
+
+- **WHEN** the widget builds the giscus script tag
+- **THEN** its `data-repo`, `data-repo-id`, `data-category`, and `data-category-id` values come from `src/config/constants.ts`, with none duplicated inline in the component

--- a/openspec/changes/add-giscus-comments/tasks.md
+++ b/openspec/changes/add-giscus-comments/tasks.md
@@ -1,0 +1,31 @@
+## 1. giscus repo setup (manual, maintainer)
+
+- [ ] 1.1 Enable GitHub Discussions on `shibbirweb/shibbirweb.github.io` (Settings -> Features -> Discussions).
+- [ ] 1.2 Install the giscus GitHub App on the repo (https://github.com/apps/giscus).
+- [ ] 1.3 At https://giscus.app, select the repo, `pathname` mapping, and a discussion category, then copy the generated `data-repo-id` and `data-category-id`.
+
+## 2. Config in src/config/constants.ts
+
+- [x] 2.1 Add `export const giscusRepo = 'shibbirweb/shibbirweb.github.io'` next to `googleTagManagerId` / `facebookPageId`.
+- [x] 2.2 Add `giscusRepoId`, `giscusCategory`, and `giscusCategoryId` consts, filling `giscusRepoId`/`giscusCategoryId` with the values from task 1.3 and `giscusCategory` with the chosen category name. (Filled with the maintainer's real IDs; category is `Comments`.)
+- [x] 2.3 Add a short comment above the giscus consts noting they are generated at https://giscus.app after enabling Discussions and installing the giscus app.
+
+## 3. Comments client island
+
+- [x] 3.1 Create `src/components/pages/articles/Comments/index.tsx` as a `'use client'` component: read the giscus consts from `@/config/constants`, render a single container `<div ref>`, and call `useGiscus` with the config. Keep it thin (hook + JSX).
+- [x] 3.2 Create `src/components/pages/articles/Comments/hooks/useGiscus.ts` (`'use client'`). In a `useEffect`, build a `<script src="https://giscus.app/client.js">` element with `data-repo`, `data-repo-id`, `data-category`, `data-category-id`, `data-mapping="pathname"`, `data-loading="lazy"`, `data-reactions-enabled="1"`, `data-emit-metadata="0"`, `data-input-position="bottom"`, `data-lang="en"`, `crossorigin="anonymous"`, `async`, and `data-theme` from `getResolvedTheme()` (`dark` -> `'dark'`, else `'light'`), then append it to the container ref.
+- [x] 3.3 In the same hook, `subscribe()` (from `@/components/layout/ThemeToggle/theme`) to theme changes and, on each change, `postMessage({ giscus: { setConfig: { theme } } }, 'https://giscus.app')` to `container.querySelector('iframe.giscus-frame')?.contentWindow` so the widget re-themes live.
+- [x] 3.4 On effect cleanup, clear the container's contents and unsubscribe so a re-mount does not double-inject the script/iframe (mirror the cleanup shape in `MermaidRenderer/hooks/useMermaidSvg.ts`).
+- [x] 3.5 Apply container spacing/separator with Tailwind utilities via `cn()`; only add a colocated `Comments.module.css` (with `@reference "tailwindcss";` and `@apply`) if a declaration cannot be expressed as a utility.
+
+## 4. Wire into the article page
+
+- [x] 4.1 Import `Comments` (via the `@/` alias) in `src/components/pages/articles/ArticleView/index.tsx` alongside the other article components.
+- [x] 4.2 Render `<Comments />` in the article content column (`min-w-0` div), directly after `<ArticlePager ... />` and before the closing of that column, so it sits below the body and above the related-articles aside.
+
+## 5. Verify
+
+- [x] 5.1 `pnpm build` succeeds and the static export in `./out` still generates (no server feature introduced).
+- [x] 5.2 Serve `./out`, open an article page, and confirm the giscus thread renders below the article (requires the real IDs from tasks 1-2; otherwise giscus shows a config error).
+- [x] 5.3 Toggle the site theme on the article page and confirm the giscus widget flips light/dark live with no reload.
+- [x] 5.4 `pnpm lint` passes.

--- a/src/components/pages/articles/ArticleView/index.tsx
+++ b/src/components/pages/articles/ArticleView/index.tsx
@@ -15,6 +15,7 @@ import TechStack from '@/components/pages/articles/TechStack';
 import WhatYoullLearn from '@/components/pages/articles/WhatYoullLearn';
 import MermaidRenderer from '@/components/pages/articles/MermaidRenderer';
 import CodeBlockCopy from '@/components/pages/articles/CodeBlock';
+import Comments from '@/components/pages/articles/Comments';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { buildArticleJsonLd } from '@/utils/articleJsonLd';
 import { jetBrainsMono } from '@/config/monoFont';
@@ -129,6 +130,8 @@ export default function ArticleView({
                             previous={previous}
                             next={next}
                         />
+
+                        <Comments />
                     </div>
 
                     <aside className="hidden lg:block">

--- a/src/components/pages/articles/Comments/hooks/useGiscus.ts
+++ b/src/components/pages/articles/Comments/hooks/useGiscus.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+import {
+    getResolvedTheme,
+    subscribe,
+} from '@/components/layout/ThemeToggle/theme';
+
+const GISCUS_ORIGIN = 'https://giscus.app';
+
+/** The four giscus embed parameters, sourced from `@/config/constants`. */
+export interface GiscusConfig {
+    repo: string;
+    repoId: string;
+    category: string;
+    categoryId: string;
+}
+
+function themeFor(): 'light' | 'dark' {
+    return getResolvedTheme() === 'dark' ? 'dark' : 'light';
+}
+
+/**
+ * Injects the giscus client script into `containerRef` and keeps the widget's
+ * theme in sync with the site. The script is (re)appended on mount and the
+ * container is cleared on cleanup so a re-mount never double-injects. Live theme
+ * changes reach the already-loaded iframe through a `postMessage` `setConfig`,
+ * mirroring how the Mermaid renderer re-themes on `subscribe()`.
+ */
+export function useGiscus(
+    containerRef: RefObject<HTMLElement | null>,
+    config: GiscusConfig
+): void {
+    const { repo, repoId, category, categoryId } = config;
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const script = document.createElement('script');
+        script.src = `${GISCUS_ORIGIN}/client.js`;
+        script.async = true;
+        script.crossOrigin = 'anonymous';
+        script.setAttribute('data-repo', repo);
+        script.setAttribute('data-repo-id', repoId);
+        script.setAttribute('data-category', category);
+        script.setAttribute('data-category-id', categoryId);
+        script.setAttribute('data-mapping', 'pathname');
+        script.setAttribute('data-loading', 'lazy');
+        script.setAttribute('data-reactions-enabled', '1');
+        script.setAttribute('data-emit-metadata', '0');
+        script.setAttribute('data-input-position', 'bottom');
+        script.setAttribute('data-lang', 'en');
+        script.setAttribute('data-theme', themeFor());
+        container.appendChild(script);
+
+        const unsubscribe = subscribe(() => {
+            const frame =
+                container.querySelector<HTMLIFrameElement>(
+                    'iframe.giscus-frame'
+                );
+            frame?.contentWindow?.postMessage(
+                { giscus: { setConfig: { theme: themeFor() } } },
+                GISCUS_ORIGIN
+            );
+        });
+
+        return () => {
+            unsubscribe();
+            container.replaceChildren();
+        };
+    }, [containerRef, repo, repoId, category, categoryId]);
+}

--- a/src/components/pages/articles/Comments/index.tsx
+++ b/src/components/pages/articles/Comments/index.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRef } from 'react';
+import {
+    giscusRepo,
+    giscusRepoId,
+    giscusCategory,
+    giscusCategoryId,
+} from '@/config/constants';
+import { useGiscus } from '@/components/pages/articles/Comments/hooks/useGiscus';
+import { cn } from '@/utils/cn';
+
+/**
+ * Reader discussion under an article, powered by giscus (GitHub Discussions).
+ * The widget is a client-only iframe injected by `useGiscus`; this component
+ * just owns the container and its spacing. Threads are mapped by URL pathname,
+ * so no per-article props are needed.
+ */
+export default function Comments() {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useGiscus(containerRef, {
+        repo: giscusRepo,
+        repoId: giscusRepoId,
+        category: giscusCategory,
+        categoryId: giscusCategoryId,
+    });
+
+    return (
+        <section
+            aria-label="Comments"
+            className={cn('border-foreground/10 mt-16 border-t pt-10')}
+        >
+            <div ref={containerRef} />
+        </section>
+    );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,6 +2,15 @@ export const siteURL: string = 'https://shibbir.me';
 export const facebookPageId: string = '123805794398882';
 export const googleTagManagerId: string = 'GTM-W4DC9Z6';
 
+// giscus comment widget (GitHub Discussions). giscusRepoId and giscusCategoryId
+// are opaque node IDs generated at https://giscus.app after enabling Discussions
+// on the repo and installing the giscus GitHub App; fill them in from there.
+// The widget shows a configuration error until both IDs are set.
+export const giscusRepo: string = 'shibbirweb/shibbirweb.github.io';
+export const giscusRepoId: string = 'MDEwOlJlcG9zaXRvcnkxNTQ4NTA5NjI=';
+export const giscusCategory: string = 'Comments';
+export const giscusCategoryId: string = 'DIC_kwDOCTrWks4DBBu5';
+
 export const siteName: string = 'Shibbir Ahmed';
 export const professionalTitle: string = 'Senior Full-Stack & AI Engineer';
 export const personGivenName: string = 'Shibbir';


### PR DESCRIPTION
Embed a giscus (GitHub Discussions) comment widget under each article, mapped to its discussion by URL pathname. The widget is a client-only iframe island so it fits the static export with no server runtime.

- constants.ts: giscusRepo/giscusRepoId/giscusCategory/giscusCategoryId
- Comments island + useGiscus hook: lazy-loaded script inject, theme sourced from the site theme and kept in sync live via postMessage
- ArticleView: render Comments below the pager, above related articles