### PR TITLE
fix(comments): make giscus corner glow neutral and unobtrusive

### DIFF
--- a/openspec/changes/generate-giscus-theme-css/design.md
+++ b/openspec/changes/generate-giscus-theme-css/design.md
@@ -16,7 +16,7 @@ theme generator fits that exact pattern.
 
 **Goals:**
 - Single source of truth: the giscus theme derives from `globals.css` tokens.
-- ProjectCard corner-aurora glow on the card background (strengthened on hover).
+- Faint neutral corner glow on the card (ProjectCard motif, no color, subtle hover lift).
 - Follow the existing generated-`public/`-asset convention (gitignored, built).
 
 **Non-Goals:**
@@ -47,16 +47,16 @@ committed files have, deriving foreground-tinted `rgba()` values via a
 static GitHub prettylights maps. Only the `main` background changes (below). Output
 is written with `fs.writeFileSync`, mirroring `buildArticleCoverSvg`.
 
-**3. ProjectCard corner-aurora glow, on a pseudo-layer that fades on hover.**
+**3. Faint neutral corner glow, on a pseudo-layer that fades on hover.**
 Replace `main { background: rgba(foreground, 0.025) }` with the ProjectCard model:
 `main` becomes a positioned, isolated stacking context with a transparent
 background; `main::before` (z-index -2) paints the opaque `<background>` base;
-`main::after` (z-index -1) paints the three diffuse top-left `radial-gradient`
-washes (`color-mix(in oklab, oklch(0.72 0.16 <hue>) <strength>%, transparent)`,
-cool blue/indigo/violet hues) at `opacity: 0.6`, fading to `1` on `main:hover` via
-an `opacity` transition (motion-safe). Opacity is used because `background-image`
-cannot transition. Hues and strengths are script constants (like ProjectCard's own
-glow); the base and text stay palette-driven.
+`main::after` (z-index -1) paints three diffuse top-left `radial-gradient` washes
+of the foreground tone (`rgba(<foreground>, ~0.05)`, deliberately NEUTRAL, no color,
+so it reads as a barely-there tonal gradient matched to the card) at `opacity: 0.7`,
+fading to `1` on `main:hover` via an `opacity` transition (motion-safe) for a very
+minimal lift. Opacity is used because `background-image` cannot transition. The wash
+color is the palette foreground; alpha/opacity are small script constants.
 
 **4. Gitignore + untrack the two files.** Add them to `.gitignore` and
 `git rm --cached` them, so they are build output like `/public/og/`. The deploy

--- a/openspec/changes/generate-giscus-theme-css/proposal.md
+++ b/openspec/changes/generate-giscus-theme-css/proposal.md
@@ -4,7 +4,8 @@ The giscus comment theme lives in two hand-authored, committed files
 (`public/giscus-light.css`, `public/giscus-dark.css`) that duplicate the site
 palette hexes already defined in `src/app/globals.css`, so they drift when the
 palette changes. And the comment card background is a flat solid fill rather than a
-gradient glow that matches the site's cards (the ProjectCard corner aurora).
+faint neutral tonal glow matched to the card (a ProjectCard-style corner wash),
+kept subtle so it does not draw the eye.
 
 ## What Changes
 
@@ -12,8 +13,9 @@ gradient glow that matches the site's cards (the ProjectCard corner aurora).
   that reads the palette tokens from `src/app/globals.css` (the single source) and
   emits `public/giscus-light.css` and `public/giscus-dark.css`, so the theme stays
   in sync with the site colors automatically.
-- Give the giscus card the same corner aurora glow as `ProjectCard` (soft top-left
-  `oklch` radial washes, strengthened on hover), replacing the solid fill.
+- Give the giscus card a faint neutral corner glow in the `ProjectCard` motif (soft
+  top-left radial washes of the foreground tone, no color, with a very subtle lift
+  on hover), replacing the solid fill.
 - Chain the generator into the `dev` and `build` npm scripts, gitignore the two
   generated files, and remove their committed copies from tracking (following the
   repo convention for generated `public/` assets such as `/public/og/`).
@@ -28,8 +30,8 @@ gradient glow that matches the site's cards (the ProjectCard corner aurora).
 
 - `article-comments`: the custom giscus theme is now generated at build time from
   the site's `globals.css` palette (single source of truth) instead of committed
-  hardcoded CSS, and the comment card renders the ProjectCard corner aurora glow
-  (strengthened on hover) rather than a solid fill.
+  hardcoded CSS, and the comment card renders a faint neutral corner glow (subtle
+  lift on hover) rather than a solid fill.
 
 ## Impact
 

--- a/openspec/changes/generate-giscus-theme-css/specs/article-comments/spec.md
+++ b/openspec/changes/generate-giscus-theme-css/specs/article-comments/spec.md
@@ -9,8 +9,9 @@ so the theme stays in sync with the palette. The generator SHALL run before the
 Next.js build (chained in the `dev` and `build` npm scripts, like the existing
 `generate-covers` step), and the two generated files SHALL be gitignored and
 regenerated each build rather than committed. The generated theme SHALL render the
-comment card with the same corner aurora glow as `ProjectCard` (soft top-left,
-multi-hue `oklch` radial washes, strengthened on hover), and SHALL preserve the
+comment card with a faint neutral corner glow in the `ProjectCard` motif (soft
+top-left radial washes of the foreground tone, no color, kept subtle so it does not
+draw the eye, with a very minimal lift on hover), and SHALL preserve the
 existing theme behavior (site palette, inverted primary button, rounded write-box
 card, crimson inline-code chips) in both light and dark.
 
@@ -27,10 +28,10 @@ card, crimson inline-code chips) in both light and dark.
 - **THEN** the next build regenerates the giscus CSS so its colors match the new
   token, with no manual edit to the giscus files
 
-#### Scenario: Comment card shows the ProjectCard aurora glow
+#### Scenario: Comment card shows a faint neutral corner glow
 
 - **WHEN** the custom theme loads inside the widget on the deployed site
-- **THEN** the comment card background shows a soft top-left aurora glow (the same
-  `oklch` radial-wash motif as `ProjectCard`) rather than a solid fill, and the glow
-  fades up smoothly on hover (a pseudo-layer `opacity` transition), in both light
-  and dark
+- **THEN** the comment card background shows a faint neutral top-left tonal glow
+  (soft radial washes of the foreground tone, no color) rather than a solid fill,
+  subtle enough not to draw the eye, and it fades up minimally and smoothly on hover
+  (a pseudo-layer `opacity` transition), in both light and dark

--- a/openspec/changes/generate-giscus-theme-css/tasks.md
+++ b/openspec/changes/generate-giscus-theme-css/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Create `scripts/generate-giscus-themes.ts` (a `tsx` script ending in a top-level `main()`, mirroring `scripts/generate-covers.ts`)
 - [x] 1.2 Parse `src/app/globals.css`: extract `--background` and `--foreground` from the `:root {` block (light) and the `:root[data-theme='dark'] {` block (dark); throw if any token is missing
 - [x] 1.3 Add a `hex -> {r,g,b}` helper and a `buildGiscusTheme(palette, mode)` that returns the full CSS string: the 73 Primer `--color-*` variables (foreground-tinted rgba surfaces/borders/buttons, inverted primary button, `hsl(234 ...)` accent, static GitHub prettylights maps) plus the element rules (textarea top radius, `-extras` bottom radius, `.btn-primary` radius/weight, crimson inline code, code block)
-- [x] 1.4 In the `main` block, set the ProjectCard corner-aurora glow: three top-left `radial-gradient` washes (`color-mix(in oklab, oklch(0.72 0.16 <hue>) <strength>%, transparent)`, cool blue/indigo/violet hues) over `background-color: <background>`, plus a `main:hover` rule that raises the strength; keep the `foreground/10` border, `1rem` radius, and padding
+- [x] 1.4 Set a faint neutral corner glow (ProjectCard motif) via pseudo-layers: `main` transparent + isolated; `main::before` opaque `<background>` base; `main::after` three top-left `radial-gradient` washes of the foreground tone (`rgba(<foreground>, ~0.05)`, no color) at `opacity: 0.7`, fading to `1` on `main:hover` (motion-safe `opacity` transition); keep the `foreground/10` border, `1rem` radius, and padding
 - [x] 1.5 Write `public/giscus-light.css` and `public/giscus-dark.css` with `fs.writeFileSync`
 
 ## 2. Wire into build + tracking

--- a/scripts/generate-giscus-themes.ts
+++ b/scripts/generate-giscus-themes.ts
@@ -75,33 +75,26 @@ function hexToRgb(hex: string): [number, number, number] {
 
 // Corner aurora glow, mirroring ProjectCard.module.css: three diffuse radial
 // washes anchored top-left, using oklch(0.72 0.16 <hue>) hues, softly present and
-// strengthened on hover (ProjectCard reveals its glow on hover). Cool on-theme
-// hues (blue / indigo / violet) rather than the site accent alone.
-const GLOW_HUES = [210, 250, 290] as const;
-// Full glow strength (per mode), painted on the ::after layer; the resting state
-// shows it at BASE_OPACITY and fades to 1 on hover, mirroring ProjectCard.
-// Kept deliberately faint: barely noticeable at rest, a gentle lift on hover.
-const GLOW_FULL: Record<Mode, number> = { light: 7, dark: 9 };
-const BASE_OPACITY = 0.35;
+// strengthened on hover. Deliberately NEUTRAL (a faint foreground-toned wash, no
+// color) so it reads as a barely-there tonal gradient matched to the card, not an
+// eye-catching colored glow; the hover lift is minimal.
+// Peak per-wash alpha of the foreground tint (per mode); the resting state shows it
+// at BASE_OPACITY and fades to 1 on hover.
+const GLOW_ALPHA: Record<Mode, number> = { light: 0.05, dark: 0.06 };
+const BASE_OPACITY = 0.7;
 
-/** ProjectCard-style top-left aurora: three layered radial washes at `strength`. */
-function aurora(strength: number): string {
-    const [a, b, c] = GLOW_HUES;
-    const wash = (
-        size: string,
-        at: string,
-        hue: number,
-        fade: string
-    ): string =>
+/** Top-left tonal glow: three layered radial washes of `color` at `alpha`. */
+function aurora(color: string, alpha: number): string {
+    const wash = (size: string, at: string, fade: string): string =>
         `radial-gradient(
         ${size} at ${at},
-        color-mix(in oklab, oklch(0.72 0.16 ${hue}) ${strength}%, transparent),
+        rgba(${color}, ${alpha}),
         transparent ${fade}
     )`;
     return [
-        wash('80% 85%', '0% 0%', a, '78%'),
-        wash('70% 75%', '20% 4%', b, '75%'),
-        wash('65% 70%', '2% 24%', c, '72%'),
+        wash('80% 85%', '0% 0%', '78%'),
+        wash('70% 75%', '20% 4%', '75%'),
+        wash('65% 70%', '2% 24%', '72%'),
     ].join(',\n    ');
 }
 
@@ -158,7 +151,6 @@ function buildTheme(mode: Mode, palette: Palette): string {
     // foreground / background tints
     const fg = (a: number) => `rgba(${r}, ${g}, ${b}, ${a})`;
     const bgc = (a: number) => `rgba(${br}, ${bg}, ${bb}, ${a})`;
-    const glowFull = GLOW_FULL[mode];
     const accent = ACCENT[mode];
     const status = STATUS[mode];
     const syntax = Object.entries(SYNTAX[mode])
@@ -279,7 +271,7 @@ main::after {
     border-radius: inherit;
     pointer-events: none;
     opacity: ${BASE_OPACITY};
-    background-image: ${aurora(glowFull)};
+    background-image: ${aurora(`${r}, ${g}, ${b}`, GLOW_ALPHA[mode])};
 }
 main:hover::after {
     opacity: 1;


### PR DESCRIPTION
Swap the colored oklch aurora for a neutral foreground-toned wash (rgba(foreground, ~0.05), no color) so the corner glow matches the card instead of reading blue, and raise resting opacity to 0.7 so the hover lift is very minimal. The gradient is present but should not draw the eye.