### PR TITLE
fix(comments): use the near-background teal tint for the giscus corne…

### DIFF
--- a/openspec/changes/generate-giscus-theme-css/design.md
+++ b/openspec/changes/generate-giscus-theme-css/design.md
@@ -16,7 +16,8 @@ theme generator fits that exact pattern.
 
 **Goals:**
 - Single source of truth: the giscus theme derives from `globals.css` tokens.
-- Faint neutral corner glow on the card (ProjectCard motif, no color, subtle hover lift).
+- Faint teal corner glow on the card (ProjectCard motif, the site's near-background
+  `--section-swell-teal` tint, subtle hover lift).
 - Follow the existing generated-`public/`-asset convention (gitignored, built).
 
 **Non-Goals:**
@@ -32,8 +33,8 @@ theme generator fits that exact pattern.
 The user's intent is "generate based on our current colors," and `globals.css` is
 already the sole source. The generator reads the file and extracts, scoped to the
 `:root {` block (light) and the `:root[data-theme='dark'] {` block (dark), the
-`--background` and `--foreground` tokens, throwing if any is missing (guards a
-format change). Alternative considered: a new
+`--background`, `--foreground`, and `--section-swell-teal` tokens, throwing if any
+is missing (guards a format change). Alternative considered: a new
 `src/config/palette.ts` consumed by both globals.css and the script, rejected
 because Tailwind v4 CSS-first cannot import TS, so it would create a second copy,
 the opposite of the goal.
@@ -47,16 +48,18 @@ committed files have, deriving foreground-tinted `rgba()` values via a
 static GitHub prettylights maps. Only the `main` background changes (below). Output
 is written with `fs.writeFileSync`, mirroring `buildArticleCoverSvg`.
 
-**3. Faint neutral corner glow, on a pseudo-layer that fades on hover.**
+**3. Faint teal corner glow, on a pseudo-layer that fades on hover.**
 Replace `main { background: rgba(foreground, 0.025) }` with the ProjectCard model:
 `main` becomes a positioned, isolated stacking context with a transparent
 background; `main::before` (z-index -2) paints the opaque `<background>` base;
-`main::after` (z-index -1) paints three diffuse top-left `radial-gradient` washes
-of the foreground tone (`rgba(<foreground>, ~0.05)`, deliberately NEUTRAL, no color,
-so it reads as a barely-there tonal gradient matched to the card) at `opacity: 0.7`,
-fading to `1` on `main:hover` via an `opacity` transition (motion-safe) for a very
-minimal lift. Opacity is used because `background-image` cannot transition. The wash
-color is the palette foreground; alpha/opacity are small script constants.
+`main::after` (z-index -1) paints three diffuse top-left `radial-gradient` washes of
+the site's `--section-swell-teal` tint (light `#e6f1ef` white-teal / dark `#0a1413`
+near-black teal, both right next to the background, so the corner reads as a
+barely-there teal wash matched to the card, not an eye-catching color) at
+`opacity: 0.75`, fading to `1` on `main:hover` via an `opacity` transition
+(motion-safe) for a very minimal lift. Opacity is used because `background-image`
+cannot transition. The wash color is the palette teal token; alpha/opacity are small
+script constants.
 
 **4. Gitignore + untrack the two files.** Add them to `.gitignore` and
 `git rm --cached` them, so they are build output like `/public/og/`. The deploy

--- a/openspec/changes/generate-giscus-theme-css/proposal.md
+++ b/openspec/changes/generate-giscus-theme-css/proposal.md
@@ -4,8 +4,8 @@ The giscus comment theme lives in two hand-authored, committed files
 (`public/giscus-light.css`, `public/giscus-dark.css`) that duplicate the site
 palette hexes already defined in `src/app/globals.css`, so they drift when the
 palette changes. And the comment card background is a flat solid fill rather than a
-faint neutral tonal glow matched to the card (a ProjectCard-style corner wash),
-kept subtle so it does not draw the eye.
+faint teal glow matched to the card (a ProjectCard-style corner wash using the
+site's near-background teal tint), kept subtle so it does not draw the eye.
 
 ## What Changes
 
@@ -13,9 +13,9 @@ kept subtle so it does not draw the eye.
   that reads the palette tokens from `src/app/globals.css` (the single source) and
   emits `public/giscus-light.css` and `public/giscus-dark.css`, so the theme stays
   in sync with the site colors automatically.
-- Give the giscus card a faint neutral corner glow in the `ProjectCard` motif (soft
-  top-left radial washes of the foreground tone, no color, with a very subtle lift
-  on hover), replacing the solid fill.
+- Give the giscus card a faint teal corner glow in the `ProjectCard` motif (soft
+  top-left radial washes of the site's near-background `--section-swell-teal` tint,
+  with a very subtle lift on hover), replacing the solid fill.
 - Chain the generator into the `dev` and `build` npm scripts, gitignore the two
   generated files, and remove their committed copies from tracking (following the
   repo convention for generated `public/` assets such as `/public/og/`).
@@ -30,8 +30,8 @@ kept subtle so it does not draw the eye.
 
 - `article-comments`: the custom giscus theme is now generated at build time from
   the site's `globals.css` palette (single source of truth) instead of committed
-  hardcoded CSS, and the comment card renders a faint neutral corner glow (subtle
-  lift on hover) rather than a solid fill.
+  hardcoded CSS, and the comment card renders a faint teal corner glow (subtle lift
+  on hover) rather than a solid fill.
 
 ## Impact
 

--- a/openspec/changes/generate-giscus-theme-css/specs/article-comments/spec.md
+++ b/openspec/changes/generate-giscus-theme-css/specs/article-comments/spec.md
@@ -9,9 +9,10 @@ so the theme stays in sync with the palette. The generator SHALL run before the
 Next.js build (chained in the `dev` and `build` npm scripts, like the existing
 `generate-covers` step), and the two generated files SHALL be gitignored and
 regenerated each build rather than committed. The generated theme SHALL render the
-comment card with a faint neutral corner glow in the `ProjectCard` motif (soft
-top-left radial washes of the foreground tone, no color, kept subtle so it does not
-draw the eye, with a very minimal lift on hover), and SHALL preserve the
+comment card with a faint teal corner glow in the `ProjectCard` motif (soft
+top-left radial washes of the site's near-background `--section-swell-teal` tint,
+kept subtle so it does not draw the eye, with a very minimal lift on hover), and
+SHALL preserve the
 existing theme behavior (site palette, inverted primary button, rounded write-box
 card, crimson inline-code chips) in both light and dark.
 
@@ -19,7 +20,8 @@ card, crimson inline-code chips) in both light and dark.
 
 - **WHEN** the build runs (or the generator script is run directly)
 - **THEN** `public/giscus-light.css` and `public/giscus-dark.css` are produced from
-  the `--background` / `--foreground` tokens read out of `src/app/globals.css`, and
+  the `--background` / `--foreground` / `--section-swell-teal` tokens read out of
+  `src/app/globals.css`, and
   both files are emitted into the static export
 
 #### Scenario: Changing a palette token updates the theme
@@ -28,10 +30,10 @@ card, crimson inline-code chips) in both light and dark.
 - **THEN** the next build regenerates the giscus CSS so its colors match the new
   token, with no manual edit to the giscus files
 
-#### Scenario: Comment card shows a faint neutral corner glow
+#### Scenario: Comment card shows a faint teal corner glow
 
 - **WHEN** the custom theme loads inside the widget on the deployed site
-- **THEN** the comment card background shows a faint neutral top-left tonal glow
-  (soft radial washes of the foreground tone, no color) rather than a solid fill,
-  subtle enough not to draw the eye, and it fades up minimally and smoothly on hover
-  (a pseudo-layer `opacity` transition), in both light and dark
+- **THEN** the comment card background shows a faint teal top-left glow (soft radial
+  washes of the near-background `--section-swell-teal` tint) rather than a solid
+  fill, subtle enough not to draw the eye, and it fades up minimally and smoothly on
+  hover (a pseudo-layer `opacity` transition), in both light and dark

--- a/openspec/changes/generate-giscus-theme-css/tasks.md
+++ b/openspec/changes/generate-giscus-theme-css/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Generator script
 
 - [x] 1.1 Create `scripts/generate-giscus-themes.ts` (a `tsx` script ending in a top-level `main()`, mirroring `scripts/generate-covers.ts`)
-- [x] 1.2 Parse `src/app/globals.css`: extract `--background` and `--foreground` from the `:root {` block (light) and the `:root[data-theme='dark'] {` block (dark); throw if any token is missing
+- [x] 1.2 Parse `src/app/globals.css`: extract `--background`, `--foreground`, and `--section-swell-teal` from the `:root {` block (light) and the `:root[data-theme='dark'] {` block (dark); throw if any token is missing
 - [x] 1.3 Add a `hex -> {r,g,b}` helper and a `buildGiscusTheme(palette, mode)` that returns the full CSS string: the 73 Primer `--color-*` variables (foreground-tinted rgba surfaces/borders/buttons, inverted primary button, `hsl(234 ...)` accent, static GitHub prettylights maps) plus the element rules (textarea top radius, `-extras` bottom radius, `.btn-primary` radius/weight, crimson inline code, code block)
-- [x] 1.4 Set a faint neutral corner glow (ProjectCard motif) via pseudo-layers: `main` transparent + isolated; `main::before` opaque `<background>` base; `main::after` three top-left `radial-gradient` washes of the foreground tone (`rgba(<foreground>, ~0.05)`, no color) at `opacity: 0.7`, fading to `1` on `main:hover` (motion-safe `opacity` transition); keep the `foreground/10` border, `1rem` radius, and padding
+- [x] 1.4 Set a faint teal corner glow (ProjectCard motif) via pseudo-layers: `main` transparent + isolated; `main::before` opaque `<background>` base; `main::after` three top-left `radial-gradient` washes of the `--section-swell-teal` tint (near background) at `opacity: 0.75`, fading to `1` on `main:hover` (motion-safe `opacity` transition); keep the `foreground/10` border, `1rem` radius, and padding
 - [x] 1.5 Write `public/giscus-light.css` and `public/giscus-dark.css` with `fs.writeFileSync`
 
 ## 2. Wire into build + tracking
@@ -15,7 +15,7 @@
 ## 3. Verify
 
 - [x] 3.1 Run `pnpm exec tsx scripts/generate-giscus-themes.ts`; diff the regenerated files against the previous versions, only the `main` background (aurora glow) should differ
-- [x] 3.2 Single-source proof: change `--foreground` in `globals.css`, re-run the generator, confirm the giscus text/tint colors update; revert the token
+- [x] 3.2 Single-source proof: change a token in `globals.css` (e.g. `--foreground` or `--section-swell-teal`), re-run the generator, confirm the giscus colors/glow update; revert the token
 - [x] 3.3 `pnpm lint` + `pnpm build` succeed; both `giscus-*.css` are emitted into `./out`
 - [x] 3.4 Inject the generated CSS into the real giscus frame headless and screenshot: confirm the aurora glow renders and the button / input radius / palette are unchanged in light and dark
 - [ ] 3.5 Deploy verification (authoritative, localhost cannot render the theme): open a live article, confirm the comment card shows the ProjectCard aurora glow (strengthened on hover) in both light and dark and matches the site

--- a/scripts/generate-giscus-themes.ts
+++ b/scripts/generate-giscus-themes.ts
@@ -16,6 +16,7 @@ type Mode = 'light' | 'dark';
 interface Palette {
     background: string;
     foreground: string;
+    teal: string;
 }
 
 const GLOBALS = path.join(process.cwd(), 'src/app/globals.css');
@@ -53,6 +54,7 @@ function readPalettes(): Record<Mode, Palette> {
     const pick = (b: string): Palette => ({
         background: token(b, 'background'),
         foreground: token(b, 'foreground'),
+        teal: token(b, 'section-swell-teal'),
     });
     return { light: pick(light), dark: pick(dark) };
 }
@@ -75,13 +77,14 @@ function hexToRgb(hex: string): [number, number, number] {
 
 // Corner aurora glow, mirroring ProjectCard.module.css: three diffuse radial
 // washes anchored top-left, using oklch(0.72 0.16 <hue>) hues, softly present and
-// strengthened on hover. Deliberately NEUTRAL (a faint foreground-toned wash, no
-// color) so it reads as a barely-there tonal gradient matched to the card, not an
-// eye-catching colored glow; the hover lift is minimal.
-// Peak per-wash alpha of the foreground tint (per mode); the resting state shows it
-// at BASE_OPACITY and fades to 1 on hover.
-const GLOW_ALPHA: Record<Mode, number> = { light: 0.05, dark: 0.06 };
-const BASE_OPACITY = 0.7;
+// strengthened on hover. Uses the site's --section-swell-teal tint, which sits
+// right next to the background (light: a white-teal; dark: a near-black teal), so
+// the corner reads as a barely-there teal wash matched to the card, not an
+// eye-catching color; the hover lift is minimal.
+// Per-wash alpha of the teal tint (per mode); the resting state shows it at
+// BASE_OPACITY and fades to 1 on hover.
+const GLOW_ALPHA: Record<Mode, number> = { light: 0.7, dark: 0.75 };
+const BASE_OPACITY = 0.75;
 
 /** Top-left tonal glow: three layered radial washes of `color` at `alpha`. */
 function aurora(color: string, alpha: number): string {
@@ -145,9 +148,10 @@ const SYNTAX: Record<Mode, Record<string, string>> = {
 };
 
 function buildTheme(mode: Mode, palette: Palette): string {
-    const { background, foreground } = palette;
+    const { background, foreground, teal } = palette;
     const [r, g, b] = hexToRgb(foreground);
     const [br, bg, bb] = hexToRgb(background);
+    const [tr, tg, tb] = hexToRgb(teal);
     // foreground / background tints
     const fg = (a: number) => `rgba(${r}, ${g}, ${b}, ${a})`;
     const bgc = (a: number) => `rgba(${br}, ${bg}, ${bb}, ${a})`;
@@ -271,7 +275,7 @@ main::after {
     border-radius: inherit;
     pointer-events: none;
     opacity: ${BASE_OPACITY};
-    background-image: ${aurora(`${r}, ${g}, ${b}`, GLOW_ALPHA[mode])};
+    background-image: ${aurora(`${tr}, ${tg}, ${tb}`, GLOW_ALPHA[mode])};
 }
 main:hover::after {
     opacity: 1;


### PR DESCRIPTION
…r glow

Colour the corner glow with the site's --section-swell-teal token (light #e6f1ef white-teal, dark #0a1413 near-black teal) instead of a grey foreground wash, so it reads as a barely-there teal matched to the background rather than an eye-catching tint. Generator now also parses --section-swell-teal from globals.css.