### PR TITLE
perf(home): fix mobile LCP via optional hero font and deferred GTM

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata, Viewport } from 'next';
 import '@/app/globals.css';
 import {
     facebookPageId,
-    googleTagManagerId,
     jsonLdAlternateName,
     personFamilyName,
     personGivenName,
@@ -16,7 +15,7 @@ import {
     siteURL,
     twitterUsername,
 } from '@/config/constants';
-import { GoogleTagManager } from '@next/third-parties/google';
+import DeferredGoogleTagManager from '@/components/analytics/DeferredGoogleTagManager';
 import PageviewTracker from '@/components/analytics/PageviewTracker';
 import { JsonLdScript } from '@/components/seo/JsonLdScript';
 import { ThemeScript } from '@/components/layout/ThemeToggle/ThemeScript';
@@ -131,7 +130,7 @@ export default function RootLayout({
             </head>
             {process.env.NODE_ENV === 'production' && (
                 <>
-                    <GoogleTagManager gtmId={googleTagManagerId} />
+                    <DeferredGoogleTagManager />
                     <PageviewTracker />
                 </>
             )}

--- a/src/components/analytics/DeferredGoogleTagManager/index.tsx
+++ b/src/components/analytics/DeferredGoogleTagManager/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { GoogleTagManager } from '@next/third-parties/google';
+import { googleTagManagerId } from '@/config/constants';
+
+/**
+ * Mounts GTM only after the window `load` event plus an idle callback, keeping
+ * its ~274KB `gtm.js` download out of the LCP bandwidth window on throttled
+ * mobile (the home hero name is the LCP element). `@next/third-parties`'
+ * `GoogleTagManager` loads its script `afterInteractive` with no way to override
+ * the strategy, so gating the render is how we defer it.
+ *
+ * No pageviews are lost: `sendGTMEvent` pushes into `window.dataLayer[]` (created
+ * lazily), so events fired before GTM boots buffer in the array and are processed
+ * once it initializes. Prod-gated by the caller, same as the rest of GTM.
+ */
+export default function DeferredGoogleTagManager() {
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        const scheduleMount = () => {
+            const idle =
+                window.requestIdleCallback ??
+                ((callback: IdleRequestCallback) =>
+                    window.setTimeout(() => callback({} as IdleDeadline), 1));
+            idle(() => setMounted(true));
+        };
+
+        if (document.readyState === 'complete') {
+            scheduleMount();
+            return;
+        }
+
+        window.addEventListener('load', scheduleMount, { once: true });
+        return () => window.removeEventListener('load', scheduleMount);
+    }, []);
+
+    if (!mounted) return null;
+
+    return <GoogleTagManager gtmId={googleTagManagerId} />;
+}

--- a/src/config/fonts.ts
+++ b/src/config/fonts.ts
@@ -10,11 +10,18 @@ export const notoSans = Noto_Sans({
 });
 
 // Zain is the display font, scoped to the home hero (the large name + title)
-// by applying `zain.variable` there, so it ships only on the home page.
+// by applying `zain.variable` there, so it ships only on the home page. The hero
+// name is the home page's LCP element, so Zain uses `display: 'optional'`: on a
+// fast connection it loads inside the ~100ms block window and paints as Zain; on
+// a slow (throttled mobile) connection the browser keeps the matched fallback for
+// the page instead of re-painting late, so LCP registers at the fallback paint
+// (== FCP) rather than waiting on the font. It applies as Zain on the next visit
+// once cached. The fallback box is already well matched (CLS stays 0).
 export const zain = Zain({
     variable: '--font-zain-sans-serif',
     subsets: ['latin'],
     weight: ['400', '700'],
+    display: 'optional',
 });
 
 // JetBrains Mono is intentionally NOT defined here. It lives in its own module


### PR DESCRIPTION
Mobile Lighthouse LCP was 5.8s (score 75) while desktop stayed 95+. The LCP element is the hero name in Zain; with display:swap it re-registered LCP when Zain arrived late on throttled mobile, where the download competed with GTM's ~274KB gtm.js in the LCP window.

- Zain now uses display:optional, so on slow connections LCP registers at the well-matched fallback paint (== FCP) instead of waiting on the font; a fast connection still paints Zain within the block window. CLS stays 0.
- GTM is wrapped in DeferredGoogleTagManager, mounted after the window load event plus an idle callback, keeping gtm.js out of the LCP bandwidth window. sendGTMEvent buffers to dataLayer[] so no pageviews are lost.