### PR TITLE
feat(contact): replace mailto with Web3Forms contact form

### DIFF
--- a/src/components/layout/ThemeToggle/hooks/useResolvedTheme.ts
+++ b/src/components/layout/ThemeToggle/hooks/useResolvedTheme.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+    getResolvedTheme,
+    subscribe,
+    type ResolvedTheme,
+} from '@/components/layout/ThemeToggle/theme';
+
+/**
+ * Returns the concrete resolved theme ('light' | 'dark') and updates whenever it
+ * changes: a preference switch in this tab, a cross-tab storage write, or an OS
+ * scheme flip while on 'system'. SSR-safe: starts at 'light' to match the server
+ * markup and reads the real value after mount (the pre-paint ThemeScript has
+ * already applied the correct theme to <html>).
+ */
+export function useResolvedTheme(): ResolvedTheme {
+    const [theme, setTheme] = useState<ResolvedTheme>('light');
+
+    useEffect(() => {
+        setTheme(getResolvedTheme());
+        return subscribe(() => setTheme(getResolvedTheme()));
+    }, []);
+
+    return theme;
+}

--- a/src/components/pages/home/ContactArea/ContactForm.tsx
+++ b/src/components/pages/home/ContactArea/ContactForm.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Textarea from '@/components/ui/Textarea';
+import ContactSuccess from '@/components/pages/home/ContactArea/ContactSuccess';
+import { useContactForm } from '@/components/pages/home/ContactArea/hooks/useContactForm';
+import { useHCaptcha } from '@/components/pages/home/ContactArea/hooks/useHCaptcha';
+import {
+    contactFields,
+    messageField,
+    submitLabel,
+    submittingLabel,
+} from '@/components/pages/home/ContactArea/contents';
+
+export default function ContactForm() {
+    const { setContainer, token, reset: resetCaptcha } = useHCaptcha();
+    const { values, status, errorMessage, updateField, handleSubmit, reset } =
+        useContactForm({ captchaToken: token, resetCaptcha });
+
+    if (status === 'success') {
+        return (
+            <div className="mt-10 w-full max-w-xl">
+                <ContactSuccess onResend={reset} />
+            </div>
+        );
+    }
+
+    const isSubmitting = status === 'submitting';
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            className="mt-10 flex w-full max-w-xl flex-col gap-5"
+        >
+            {contactFields.map((field) => (
+                <Input
+                    key={field.name}
+                    label={field.label}
+                    type={field.type}
+                    placeholder={field.placeholder}
+                    autoComplete={field.autoComplete}
+                    required
+                    value={values[field.name]}
+                    onChange={(event) =>
+                        updateField(field.name, event.target.value)
+                    }
+                />
+            ))}
+
+            <Textarea
+                label={messageField.label}
+                placeholder={messageField.placeholder}
+                required
+                value={values.message}
+                onChange={(event) => updateField('message', event.target.value)}
+            />
+
+            <div
+                ref={setContainer}
+                className="flex justify-center sm:justify-start"
+            />
+
+            {status === 'error' && errorMessage && (
+                <p
+                    role="status"
+                    className="text-sm text-red-600 dark:text-red-400"
+                >
+                    {errorMessage}
+                </p>
+            )}
+
+            <div className="flex flex-col items-start gap-2">
+                <Button
+                    type="submit"
+                    isLoading={isSubmitting}
+                    disabled={!token}
+                    className="w-full sm:w-auto"
+                >
+                    {isSubmitting ? submittingLabel : submitLabel}
+                </Button>
+                {!token && (
+                    <span className="text-foreground/50 text-xs">
+                        Complete the captcha to enable sending.
+                    </span>
+                )}
+            </div>
+        </form>
+    );
+}

--- a/src/components/pages/home/ContactArea/ContactSuccess.tsx
+++ b/src/components/pages/home/ContactArea/ContactSuccess.tsx
@@ -1,0 +1,40 @@
+import CheckIcon from '@/components/icons/check';
+import Button from '@/components/ui/Button';
+import {
+    resendLabel,
+    successSubtitle,
+    successTitle,
+} from '@/components/pages/home/ContactArea/contents';
+
+/**
+ * Success state shown after a message is delivered: a green tick, a short
+ * confirmation, and a "Resend again" action that clears the form for reuse.
+ */
+export default function ContactSuccess({
+    onResend,
+}: {
+    onResend: () => void;
+}) {
+    return (
+        <div
+            role="status"
+            className="border-foreground/10 bg-background/40 flex flex-col items-center gap-4 rounded-2xl border px-6 py-10 text-center"
+        >
+            <span className="flex size-14 items-center justify-center rounded-full bg-green-500/10 text-green-600 dark:text-green-400">
+                <CheckIcon className="size-7" />
+            </span>
+            <div>
+                <p className="text-lg font-semibold">{successTitle}</p>
+                <p className="text-foreground/70 mt-1 text-sm">
+                    {successSubtitle}
+                </p>
+            </div>
+            <Button
+                variant="outline"
+                onClick={onResend}
+            >
+                {resendLabel}
+            </Button>
+        </div>
+    );
+}

--- a/src/components/pages/home/ContactArea/contents.ts
+++ b/src/components/pages/home/ContactArea/contents.ts
@@ -1,0 +1,50 @@
+import type { ContactFormValues } from '@/components/pages/home/ContactArea/types';
+
+export const contactHeading = "Let's connect";
+
+export const contactIntro =
+    'Have an idea, a question, or just want to say hi? Drop me a message below and I will get back to you, or find me on any of these platforms.';
+
+export const emptyContactValues: ContactFormValues = {
+    name: '',
+    email: '',
+    message: '',
+};
+
+type ContactFieldConfig = {
+    name: keyof ContactFormValues;
+    label: string;
+    type: 'text' | 'email';
+    placeholder: string;
+    autoComplete: string;
+};
+
+export const contactFields: ContactFieldConfig[] = [
+    {
+        name: 'name',
+        label: 'Name',
+        type: 'text',
+        placeholder: 'Your name',
+        autoComplete: 'name',
+    },
+    {
+        name: 'email',
+        label: 'Email',
+        type: 'email',
+        placeholder: 'you@example.com',
+        autoComplete: 'email',
+    },
+];
+
+export const messageField = {
+    label: 'Message',
+    placeholder: 'Tell me a little about what you have in mind...',
+};
+
+export const submitLabel = 'Send message';
+export const submittingLabel = 'Sending...';
+
+export const successTitle = 'Message sent successfully';
+export const successSubtitle =
+    "Thanks for reaching out. I will get back to you soon. Need to add something?";
+export const resendLabel = 'Resend again';

--- a/src/components/pages/home/ContactArea/hooks/useContactForm.ts
+++ b/src/components/pages/home/ContactArea/hooks/useContactForm.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+import { contactProvider } from '@/lib/contact';
+import { emptyContactValues } from '@/components/pages/home/ContactArea/contents';
+import type {
+    ContactFormValues,
+    ContactStatus,
+} from '@/components/pages/home/ContactArea/types';
+
+type UseContactFormArgs = {
+    captchaToken: string | null;
+    resetCaptcha: () => void;
+};
+
+/**
+ * Owns the contact form state and submission flow. Vendor-agnostic: it only
+ * talks to `contactProvider`, never a specific service. The captcha token and
+ * its reset are injected so the captcha vendor stays a separate concern.
+ */
+export function useContactForm({
+    captchaToken,
+    resetCaptcha,
+}: UseContactFormArgs) {
+    const [values, setValues] = useState<ContactFormValues>(emptyContactValues);
+    const [status, setStatus] = useState<ContactStatus>('idle');
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    const updateField = useCallback(
+        (field: keyof ContactFormValues, value: string) => {
+            setValues((prev) => ({ ...prev, [field]: value }));
+        },
+        []
+    );
+
+    const handleSubmit = useCallback(
+        async (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            if (status === 'submitting') {
+                return;
+            }
+
+            setStatus('submitting');
+            setErrorMessage(null);
+
+            const result = await contactProvider.submit({
+                ...values,
+                captchaToken,
+            });
+
+            // hCaptcha tokens are single-use, so reset the widget either way to
+            // leave the form ready for another attempt.
+            resetCaptcha();
+
+            if (result.ok) {
+                setStatus('success');
+            } else {
+                setStatus('error');
+                setErrorMessage(
+                    result.error ??
+                        'Something went wrong sending your message. Please try again.'
+                );
+            }
+        },
+        [status, values, captchaToken, resetCaptcha]
+    );
+
+    const reset = useCallback(() => {
+        setValues(emptyContactValues);
+        setStatus('idle');
+        setErrorMessage(null);
+        resetCaptcha();
+    }, [resetCaptcha]);
+
+    return { values, status, errorMessage, updateField, handleSubmit, reset };
+}

--- a/src/components/pages/home/ContactArea/hooks/useHCaptcha.ts
+++ b/src/components/pages/home/ContactArea/hooks/useHCaptcha.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { hcaptchaSiteKey } from '@/config/constants';
+import { useResolvedTheme } from '@/components/layout/ThemeToggle/hooks/useResolvedTheme';
+import type { ResolvedTheme } from '@/components/layout/ThemeToggle/theme';
+
+const HCAPTCHA_SCRIPT_SRC = 'https://js.hcaptcha.com/1/api.js?render=explicit';
+
+let scriptPromise: Promise<void> | null = null;
+
+/**
+ * Loads the hCaptcha API script exactly once (guarded by a module-level
+ * promise) and resolves when `window.hcaptcha` is ready. SSR-safe: it only
+ * touches the DOM in the browser.
+ */
+function loadHCaptchaScript(): Promise<void> {
+    if (typeof window === 'undefined') {
+        return Promise.resolve();
+    }
+    if (window.hcaptcha) {
+        return Promise.resolve();
+    }
+    if (scriptPromise) {
+        return scriptPromise;
+    }
+
+    scriptPromise = new Promise<void>((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = HCAPTCHA_SCRIPT_SRC;
+        script.async = true;
+        script.defer = true;
+        script.onload = () => resolve();
+        script.onerror = () => {
+            scriptPromise = null;
+            reject(new Error('Failed to load hCaptcha'));
+        };
+        document.head.appendChild(script);
+    });
+
+    return scriptPromise;
+}
+
+/**
+ * Renders an hCaptcha widget and exposes its response token. Attach the returned
+ * `setContainer` as a `ref` to a div; being a callback ref it fires with the
+ * node on mount and null on unmount, so the widget is created and torn down in
+ * step with the container (keeping the success/resend remount correct).
+ *
+ * The widget's theme is baked in at render time, so it also tracks the site
+ * theme: when the user switches light/dark the widget is removed and re-rendered
+ * with the new theme so it always matches the surrounding UI. Read `token` to
+ * know the challenge is solved; call `reset()` to clear a solved (single-use)
+ * token.
+ */
+export function useHCaptcha() {
+    const widgetIdRef = useRef<string | null>(null);
+    const nodeRef = useRef<HTMLDivElement | null>(null);
+    const renderedThemeRef = useRef<ResolvedTheme | null>(null);
+    const [token, setToken] = useState<string | null>(null);
+
+    const theme = useResolvedTheme();
+    // Read the latest theme from inside async callbacks without re-creating them.
+    const themeRef = useRef<ResolvedTheme>(theme);
+    themeRef.current = theme;
+
+    const renderWidget = useCallback(() => {
+        const node = nodeRef.current;
+        if (!node) {
+            return;
+        }
+        loadHCaptchaScript()
+            .then(() => {
+                if (
+                    !node.isConnected ||
+                    !window.hcaptcha ||
+                    widgetIdRef.current !== null
+                ) {
+                    return;
+                }
+                const activeTheme = themeRef.current;
+                widgetIdRef.current = window.hcaptcha.render(node, {
+                    sitekey: hcaptchaSiteKey,
+                    theme: activeTheme,
+                    callback: (value: string) => setToken(value),
+                    'expired-callback': () => setToken(null),
+                    'error-callback': () => setToken(null),
+                });
+                renderedThemeRef.current = activeTheme;
+            })
+            .catch(() => {
+                // Token stays null, so the submit button stays disabled and the
+                // missing-captcha hint remains visible.
+            });
+    }, []);
+
+    const removeWidget = useCallback(() => {
+        if (widgetIdRef.current !== null && window.hcaptcha) {
+            window.hcaptcha.remove(widgetIdRef.current);
+        }
+        widgetIdRef.current = null;
+        renderedThemeRef.current = null;
+        setToken(null);
+    }, []);
+
+    const setContainer = useCallback(
+        (node: HTMLDivElement | null) => {
+            nodeRef.current = node;
+            if (node) {
+                renderWidget();
+            } else {
+                removeWidget();
+            }
+        },
+        [renderWidget, removeWidget]
+    );
+
+    // Re-render with the new theme whenever it changes and a widget is mounted.
+    useEffect(() => {
+        if (
+            widgetIdRef.current !== null &&
+            renderedThemeRef.current !== theme
+        ) {
+            removeWidget();
+            renderWidget();
+        }
+    }, [theme, renderWidget, removeWidget]);
+
+    const reset = useCallback(() => {
+        setToken(null);
+        if (widgetIdRef.current !== null && window.hcaptcha) {
+            window.hcaptcha.reset(widgetIdRef.current);
+        }
+    }, []);
+
+    return { setContainer, token, reset };
+}

--- a/src/components/pages/home/ContactArea/index.tsx
+++ b/src/components/pages/home/ContactArea/index.tsx
@@ -1,6 +1,10 @@
 import SocialIcons from '@/components/pages/home/HeroArea/SocialIcons';
 import SectionHeading from '@/components/pages/common/SectionHeading';
-import { siteAuthorEmail } from '@/config/constants';
+import ContactForm from '@/components/pages/home/ContactArea/ContactForm';
+import {
+    contactHeading,
+    contactIntro,
+} from '@/components/pages/home/ContactArea/contents';
 
 export default function ContactArea() {
     return (
@@ -9,23 +13,15 @@ export default function ContactArea() {
             className="py-20 sm:py-28"
         >
             <div className="container mx-auto flex flex-col items-center px-4 text-center">
-                <SectionHeading>
-                    Let&apos;s connect
-                </SectionHeading>
+                <SectionHeading>{contactHeading}</SectionHeading>
 
                 <p className="text-foreground/70 mt-4 max-w-2xl text-lg leading-relaxed">
-                    Have an idea, a question, or just want to say hi? Reach out
-                    over email or find me on any of these platforms.
+                    {contactIntro}
                 </p>
 
-                <a
-                    href={`mailto:${siteAuthorEmail}`}
-                    className="border-foreground/20 hover:border-foreground/50 mt-10 inline-block rounded-full border px-6 py-3 text-base transition-all duration-300 hover:scale-105"
-                >
-                    {siteAuthorEmail}
-                </a>
+                <ContactForm />
 
-                <div className="mt-10">
+                <div className="mt-14">
                     <SocialIcons />
                 </div>
             </div>

--- a/src/components/pages/home/ContactArea/types.ts
+++ b/src/components/pages/home/ContactArea/types.ts
@@ -1,0 +1,30 @@
+export type ContactFormValues = {
+    name: string;
+    email: string;
+    message: string;
+};
+
+export type ContactStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+/** Minimal shape of the hCaptcha API surface we use, injected on `window` by
+ * the hCaptcha script. Widget ids are opaque strings. */
+export type HCaptchaApi = {
+    render: (
+        container: HTMLElement,
+        params: {
+            sitekey: string;
+            theme?: 'light' | 'dark';
+            callback?: (token: string) => void;
+            'expired-callback'?: () => void;
+            'error-callback'?: () => void;
+        }
+    ) => string;
+    reset: (widgetId?: string) => void;
+    remove: (widgetId: string) => void;
+};
+
+declare global {
+    interface Window {
+        hcaptcha?: HCaptchaApi;
+    }
+}

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -1,0 +1,47 @@
+import { cn } from '@/utils/cn';
+import Spinner from '@/components/ui/Spinner';
+
+type ButtonVariant = 'primary' | 'outline';
+
+const variantClassNames: Record<ButtonVariant, string> = {
+    primary:
+        'bg-foreground text-background hover:bg-foreground/85 disabled:cursor-not-allowed disabled:opacity-60',
+    outline:
+        'border-foreground/15 border hover:bg-foreground/5 disabled:cursor-not-allowed disabled:opacity-60',
+};
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: ButtonVariant;
+    isLoading?: boolean;
+};
+
+/**
+ * Reusable, theme-aware button. Styling rides the `foreground`/`background`
+ * tokens so it swaps with light/dark automatically. `isLoading` disables the
+ * button and shows a spinner before the label.
+ */
+export default function Button({
+    variant = 'primary',
+    isLoading = false,
+    type = 'button',
+    disabled,
+    className,
+    children,
+    ...rest
+}: ButtonProps) {
+    return (
+        <button
+            type={type}
+            disabled={disabled || isLoading}
+            className={cn(
+                'inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors',
+                variantClassNames[variant],
+                className
+            )}
+            {...rest}
+        >
+            {isLoading && <Spinner />}
+            {children}
+        </button>
+    );
+}

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,0 +1,40 @@
+import { useId } from 'react';
+import { cn } from '@/utils/cn';
+
+export const fieldControlClassName =
+    'border-foreground/15 bg-background/60 w-full rounded-xl border px-3.5 py-2.5 text-sm outline-none transition focus:border-foreground/40';
+
+type InputProps = React.ComponentPropsWithRef<'input'> & {
+    label: string;
+};
+
+/**
+ * Labeled text input built on the shared field styling. Theme-aware via the
+ * `foreground`/`background` tokens. Forwards `ref` (React 19 ref-as-prop) so a
+ * form can focus it, e.g. after a reset.
+ */
+export default function Input({
+    label,
+    id,
+    className,
+    ...rest
+}: InputProps) {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+
+    return (
+        <div className="flex flex-col gap-2 text-left">
+            <label
+                htmlFor={inputId}
+                className="text-sm font-medium"
+            >
+                {label}
+            </label>
+            <input
+                id={inputId}
+                className={cn(fieldControlClassName, className)}
+                {...rest}
+            />
+        </div>
+    );
+}

--- a/src/components/ui/Spinner/index.tsx
+++ b/src/components/ui/Spinner/index.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/utils/cn';
+
+/**
+ * Minimal loading spinner. The icon set has no spinner glyph, so this is a small
+ * inline SVG: a faint full ring plus a bright arc that rotates via Tailwind's
+ * `animate-spin` (motion-safe, so it stays still for reduced-motion users).
+ */
+export default function Spinner({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+            className={cn('size-4 motion-safe:animate-spin', className)}
+            {...rest}
+        >
+            <circle
+                cx="12"
+                cy="12"
+                r="9"
+                stroke="currentColor"
+                strokeWidth="3"
+                className="opacity-25"
+            />
+            <path
+                d="M21 12a9 9 0 0 0-9-9"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+            />
+        </svg>
+    );
+}

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,0 +1,37 @@
+import { useId } from 'react';
+import { cn } from '@/utils/cn';
+import { fieldControlClassName } from '@/components/ui/Input';
+
+type TextareaProps = React.ComponentPropsWithRef<'textarea'> & {
+    label: string;
+};
+
+/**
+ * Labeled multiline input. Reuses the shared field styling from Input plus a
+ * comfortable min height and vertical resize.
+ */
+export default function Textarea({
+    label,
+    id,
+    className,
+    ...rest
+}: TextareaProps) {
+    const generatedId = useId();
+    const textareaId = id ?? generatedId;
+
+    return (
+        <div className="flex flex-col gap-2 text-left">
+            <label
+                htmlFor={textareaId}
+                className="text-sm font-medium"
+            >
+                {label}
+            </label>
+            <textarea
+                id={textareaId}
+                className={cn(fieldControlClassName, 'min-h-32 resize-y', className)}
+                {...rest}
+            />
+        </div>
+    );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -73,6 +73,10 @@ export const githubURL: string = 'https://github.com/shibbirweb';
 export const facebookURL: string = 'https://www.facebook.com/shibbirweb';
 export const twitterURL: string = 'https://x.com/shibbirweb';
 
+// contact form (public keys; the site is statically exported, so these ship to the client)
+export const web3formsAccessKey: string = '91a6de0d-ce19-4432-bf0d-da3a9f3a84eb';
+export const hcaptchaSiteKey: string = '50b2fe65-b00b-4b9e-ad62-3ba471098be2';
+
 // json-ld
 export const siteDatePublished: string = '2018-12-20T15:28:28+06:00';
 export const jsonLdAlternateName: string = 'shibbirweb';

--- a/src/lib/contact/index.ts
+++ b/src/lib/contact/index.ts
@@ -1,0 +1,18 @@
+import { web3formsAccessKey } from '@/config/constants';
+import { createWeb3FormsProvider } from '@/lib/contact/providers/web3forms';
+import type { ContactProvider } from '@/lib/contact/types';
+
+/**
+ * The active contact provider. To switch vendors, import a different
+ * `create...Provider` here and assign it; the form and UI stay untouched
+ * because they depend only on the ContactProvider contract.
+ */
+export const contactProvider: ContactProvider = createWeb3FormsProvider({
+    accessKey: web3formsAccessKey,
+});
+
+export type {
+    ContactMessage,
+    ContactSubmitResult,
+    ContactProvider,
+} from '@/lib/contact/types';

--- a/src/lib/contact/providers/web3forms.ts
+++ b/src/lib/contact/providers/web3forms.ts
@@ -1,0 +1,71 @@
+import { siteAuthor } from '@/config/constants';
+import type {
+    ContactMessage,
+    ContactProvider,
+    ContactSubmitResult,
+} from '@/lib/contact/types';
+
+const WEB3FORMS_ENDPOINT = 'https://api.web3forms.com/submit';
+
+type Web3FormsConfig = {
+    accessKey: string;
+};
+
+type Web3FormsResponse = {
+    success: boolean;
+    message?: string;
+};
+
+/**
+ * Web3Forms implementation of the ContactProvider contract. Posts the message
+ * as JSON to the Web3Forms endpoint; no backend of ours is involved, which
+ * suits the static export. The hCaptcha token (when present) is forwarded as
+ * `h-captcha-response`, the field Web3Forms expects for spam verification.
+ */
+export function createWeb3FormsProvider({
+    accessKey,
+}: Web3FormsConfig): ContactProvider {
+    return {
+        id: 'web3forms',
+        async submit(message: ContactMessage): Promise<ContactSubmitResult> {
+            try {
+                const response = await fetch(WEB3FORMS_ENDPOINT, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json',
+                    },
+                    body: JSON.stringify({
+                        access_key: accessKey,
+                        name: message.name,
+                        email: message.email,
+                        message: message.message,
+                        from_name: message.name,
+                        subject: `New message from ${message.name} via ${siteAuthor}`,
+                        'h-captcha-response': message.captchaToken ?? undefined,
+                    }),
+                });
+
+                const data = (await response
+                    .json()
+                    .catch(() => null)) as Web3FormsResponse | null;
+
+                if (response.ok && data?.success) {
+                    return { ok: true };
+                }
+
+                return {
+                    ok: false,
+                    error:
+                        data?.message ??
+                        'Something went wrong sending your message. Please try again.',
+                };
+            } catch {
+                return {
+                    ok: false,
+                    error: 'Network error. Please check your connection and try again.',
+                };
+            }
+        },
+    };
+}

--- a/src/lib/contact/types.ts
+++ b/src/lib/contact/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Vendor-agnostic contact submission contract. The form depends only on these
+ * types and the active `contactProvider` (see ./index), never on a specific
+ * service, so swapping vendors is a one-line change with no UI edits.
+ */
+
+export interface ContactMessage {
+    name: string;
+    email: string;
+    message: string;
+    /** Captcha response token, or null when captcha is unavailable. The
+     * provider decides how (or whether) to use it. */
+    captchaToken: string | null;
+}
+
+export interface ContactSubmitResult {
+    ok: boolean;
+    /** Human-readable failure reason, present only when `ok` is false. */
+    error?: string;
+}
+
+export interface ContactProvider {
+    /** Stable identifier for the active provider (useful for logging/tests). */
+    readonly id: string;
+    submit(message: ContactMessage): Promise<ContactSubmitResult>;
+}


### PR DESCRIPTION
Swap the contact section's raw email link for a real form that submits through a vendor-agnostic adapter (Web3Forms implementation) with hCaptcha spam protection. Works within the static export (client-side POST, no backend).

- Add reusable UI primitives under src/components/ui (Button, Input, Textarea, Spinner), theme-aware via foreground/background tokens.
- Add src/lib/contact adapter layer: a ContactProvider contract plus a Web3Forms provider, selected in one place so the vendor can be swapped without touching the form or UI.
- Build the ContactArea form: thin server index, client ContactForm, ContactSuccess (green tick + "Resend again" that clears the form), and colocated hooks (useContactForm, useHCaptcha).
- hCaptcha widget lifecycle via callback ref so it re-arms on resend, and re-renders to match the active theme on light/dark toggle (new reusable useResolvedTheme hook).
- Store public Web3Forms access key and hCaptcha sitekey in constants.