### PR TITLE
feat(projects): split home projects into open-source tracks with resume bridge

### DIFF
--- a/src/components/pages/home/ProjectsArea/ProjectGrid.tsx
+++ b/src/components/pages/home/ProjectsArea/ProjectGrid.tsx
@@ -1,0 +1,28 @@
+import ProjectCard from '@/components/pages/home/ProjectsArea/ProjectCard';
+import { Project } from '@/components/pages/home/ProjectsArea/contents';
+
+/**
+ * A responsive project card grid. When the last row holds a single card (odd
+ * count), that card spans both columns but keeps a single-column width and
+ * centers, so it never sits lonely against the left edge. `indexOffset` keeps
+ * each card's golden-angle glow hue distinct across multiple grids on the page.
+ */
+export default function ProjectGrid({
+    projects,
+    indexOffset = 0,
+}: {
+    projects: Project[];
+    indexOffset?: number;
+}) {
+    return (
+        <ul className="grid grid-cols-1 gap-6 md:grid-cols-2 md:[&>li:last-child:nth-child(odd)]:col-span-2 md:[&>li:last-child:nth-child(odd)]:mx-auto md:[&>li:last-child:nth-child(odd)]:w-[calc(50%-0.75rem)]">
+            {projects.map((project, index) => (
+                <ProjectCard
+                    key={project.repoURL}
+                    project={project}
+                    index={indexOffset + index}
+                />
+            ))}
+        </ul>
+    );
+}

--- a/src/components/pages/home/ProjectsArea/ResumeBridge.tsx
+++ b/src/components/pages/home/ProjectsArea/ResumeBridge.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import ChevronIcon from '@/components/icons/chevron';
+
+/**
+ * In-context pointer from the open-source grid to the resume, where the
+ * professional, client-facing work lives in full. Keeps the home Projects
+ * section honest about scope without duplicating that work here.
+ */
+export default function ResumeBridge() {
+    return (
+        <div className="mt-14 text-center">
+            <p className="text-foreground/60">
+                My professional, client-facing work lives on the resume.
+            </p>
+            <Link
+                href="/resume"
+                className="group text-foreground decoration-foreground/30 hover:decoration-foreground mt-3 inline-flex items-center gap-1.5 font-medium underline underline-offset-4 transition-colors"
+            >
+                View resume
+                <ChevronIcon
+                    aria-hidden="true"
+                    className="size-4 rotate-90 transition-transform group-hover:translate-x-0.5"
+                />
+            </Link>
+        </div>
+    );
+}

--- a/src/components/pages/home/ProjectsArea/contents.ts
+++ b/src/components/pages/home/ProjectsArea/contents.ts
@@ -20,7 +20,9 @@ export type Project = {
     links?: ProjectExternalLink[];
 };
 
-export const projects: Project[] = [
+// Reusable tools published for others (VS Code Marketplace, npm). These carry
+// `links` to their distribution page alongside the source repo.
+export const packageProjects: Project[] = [
     {
         name: 'Extra Cursor Caret Height',
         category: 'VS Code Extension',
@@ -71,6 +73,19 @@ export const projects: Project[] = [
         ],
     },
     {
+        name: 'Shibbir CLI',
+        category: 'CLI Tool',
+        description:
+            'A Node.js command-line tool bundling helpful commands to run on your machine, packaging frequently used developer workflows.',
+        tech: ['Node.js', 'JavaScript'],
+        repoURL: 'https://github.com/shibbirweb/shibbir-cli',
+    },
+];
+
+// Public repos built for personal use, learning, or practice. Source only, no
+// distribution page.
+export const personalProjects: Project[] = [
+    {
         name: 'Nginx Load Balancer',
         category: 'DevOps / Infrastructure',
         description:
@@ -79,18 +94,19 @@ export const projects: Project[] = [
         repoURL: 'https://github.com/shibbirweb/p-nginx-load-balancer',
     },
     {
-        name: 'DNS Manager',
-        category: 'Developer Tool',
-        description: 'A PHP utility for managing DNS records programmatically.',
-        tech: ['PHP'],
-        repoURL: 'https://github.com/shibbirweb/dns-manager',
-    },
-    {
-        name: 'Shibbir CLI',
-        category: 'CLI Tool',
+        name: 'Cloudflare DNS & Server Manager',
+        category: 'Control Panel',
         description:
-            'A personal Node.js command-line tool that packages frequently used developer workflows.',
-        tech: ['Node.js', 'JavaScript'],
-        repoURL: 'https://github.com/shibbirweb/shibbir-cli',
+            'A Laravel and React (Inertia) control panel to manage remote servers over SSH with an in-browser terminal, provision sites, issue WordPress magic-login tokens, and manage Cloudflare DNS records.',
+        tech: [
+            'PHP',
+            'Laravel',
+            'Inertia.js',
+            'React',
+            'TypeScript',
+            'Cloudflare API',
+            'WordPress',
+        ],
+        repoURL: 'https://github.com/shibbirweb/dns-manager',
     },
 ];

--- a/src/components/pages/home/ProjectsArea/index.tsx
+++ b/src/components/pages/home/ProjectsArea/index.tsx
@@ -1,6 +1,10 @@
 import SectionHeading from '@/components/pages/common/SectionHeading';
-import ProjectCard from '@/components/pages/home/ProjectsArea/ProjectCard';
-import { projects } from '@/components/pages/home/ProjectsArea/contents';
+import ProjectGrid from '@/components/pages/home/ProjectsArea/ProjectGrid';
+import ResumeBridge from '@/components/pages/home/ProjectsArea/ResumeBridge';
+import {
+    packageProjects,
+    personalProjects,
+} from '@/components/pages/home/ProjectsArea/contents';
 
 export default function ProjectsArea() {
     return (
@@ -9,19 +13,31 @@ export default function ProjectsArea() {
             className="py-20 sm:py-28"
         >
             <div className="container mx-auto px-4">
-                <SectionHeading className="text-center">
-                    Featured Projects
-                </SectionHeading>
+                <div className="space-y-3 text-center">
+                    <SectionHeading>Open Source</SectionHeading>
+                    <p className="text-foreground/60 mx-auto max-w-xl">
+                        Tools, plugins, and experiments I build in the open.
+                    </p>
+                </div>
 
-                <ul className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
-                    {projects.map((project, index) => (
-                        <ProjectCard
-                            key={project.repoURL}
-                            project={project}
-                            index={index}
-                        />
-                    ))}
-                </ul>
+                <div className="mt-12 space-y-6">
+                    <h3 className="text-foreground/60 text-center text-sm font-bold tracking-wider uppercase">
+                        Packages &amp; Plugins
+                    </h3>
+                    <ProjectGrid projects={packageProjects} />
+                </div>
+
+                <div className="mt-14 space-y-6">
+                    <h3 className="text-foreground/60 text-center text-sm font-bold tracking-wider uppercase">
+                        Personal Projects
+                    </h3>
+                    <ProjectGrid
+                        projects={personalProjects}
+                        indexOffset={packageProjects.length}
+                    />
+                </div>
+
+                <ResumeBridge />
             </div>
         </section>
     );


### PR DESCRIPTION
Reframe the home Projects section (#work) as "Open Source" with two labeled sub-grids: "Packages & Plugins" (published for others) and "Personal Projects" (public, built for self). Add a ResumeBridge CTA pointing to /resume for the professional, client-facing work, so a home visitor discovers it in context without duplicating it here.

Extract a shared ProjectGrid that centers a lonely last card on odd counts and offsets the glow hue across grids. Drop the practice-only nginx entry from the grid and enrich the Cloudflare DNS & Server Manager entry (name, description, tech) to match the actual repo.