### PR TITLE
feat(offline): add styled /offline route from site components

### DIFF
--- a/public/offline-fallback.html
+++ b/public/offline-fallback.html
@@ -6,11 +6,15 @@
         <meta name="robots" content="noindex" />
         <title>Offline | Shibbir Ahmed</title>
         <!--
-            Served by the service worker as the navigation fallback when an
-            unvisited page is opened with no network. Deliberately a plain,
-            script-free static file (not a Next route): a Next page served under
-            an arbitrary URL would re-run the client router and render not-found,
-            clobbering this message. Self-contained so it works fully offline.
+            The minimal, last-resort offline fallback. Served by the service
+            worker as the navigation fallback when an unvisited page is opened
+            with no network. Deliberately a plain, script-free, self-contained
+            static file (not a Next route): a Next page served under an arbitrary
+            URL would re-run the client router and render not-found, clobbering
+            this message, so the styled /offline route (src/app/offline) cannot
+            play this role. That route is the primary, full-design offline page
+            (navbar, footer, theme switcher); this file only has to survive with
+            zero dependencies at any URL.
         -->
         <style>
             :root {

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,51 @@
+import SectionHeading from '@/components/pages/common/SectionHeading';
+import OfflineActions from '@/components/pages/offline/OfflineActions';
+import { siteName } from '@/config/constants';
+import { buildPageMetadata } from '@/utils/pageMetadata';
+
+const description = `You appear to be offline. Reconnect to load the page, or head back to a page you have already visited on ${siteName}'s site.`;
+
+export const metadata = buildPageMetadata({
+    title: 'Offline',
+    description,
+    path: '/offline',
+    // A utility page, never a search result.
+    robots: { index: false, follow: false },
+});
+
+export default function OfflinePage() {
+    return (
+        <main className="relative container mx-auto flex grow flex-col items-center justify-center overflow-hidden px-4 py-20 text-center sm:py-28">
+            {/* Faint display-face watermark behind the message, purely decorative. */}
+            <span
+                aria-hidden="true"
+                className="text-foreground/[0.04] font-display pointer-events-none absolute inset-x-0 top-1/2 -z-10 -translate-y-1/2 text-[28vw] leading-none font-black tracking-tighter select-none"
+            >
+                Offline
+            </span>
+
+            <span className="border-foreground/10 bg-background/60 text-foreground/70 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium backdrop-blur-lg">
+                <span
+                    aria-hidden="true"
+                    className="size-2 rounded-full bg-amber-500 motion-safe:animate-pulse"
+                />
+                No connection
+            </span>
+
+            <SectionHeading
+                as="h1"
+                className="mt-6"
+            >
+                You are offline
+            </SectionHeading>
+
+            <p className="text-foreground/70 mt-5 max-w-xl text-lg leading-relaxed text-balance">
+                Looks like your connection dropped. This page has not been saved
+                for offline reading yet. Reconnect and try again, or head back to
+                a page you have already visited.
+            </p>
+
+            <OfflineActions />
+        </main>
+    );
+}

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -23,11 +23,13 @@ declare const self: ServiceWorkerGlobalScope;
 // same-origin pages/assets plus Google Fonts keep their specific rules above.
 const runtimeCaching = defaultCache.slice(0, -2);
 
-// The static offline shell (public/offline.html) is already in the Serwist
-// precache manifest (it is a public asset), so it is available to serve as the
-// navigation fallback below. It is a plain static file rather than a Next route
-// on purpose: a Next document served under an arbitrary URL would re-run the
-// client router and render not-found instead of the offline message.
+// The minimal offline shell (public/offline-fallback.html) is already in the
+// Serwist precache manifest (it is a public asset), so it is available to serve
+// as the navigation fallback below. It is a plain static file rather than a Next
+// route on purpose: a Next document served under an arbitrary URL would re-run
+// the client router and render not-found instead of the offline message. The
+// styled /offline route (src/app/offline) is the primary, full-design offline
+// page, but being a hydrated route it cannot be the fallback for the same reason.
 const serwist = new Serwist({
     precacheEntries: self.__SW_MANIFEST,
     // The update toast drives the swap, so a new worker waits until the client
@@ -38,11 +40,11 @@ const serwist = new Serwist({
     navigationPreload: true,
     runtimeCaching,
     // When an unvisited page is opened offline, serve the precached
-    // /offline.html shell instead of the browser's default error page.
+    // /offline-fallback.html shell instead of the browser's default error page.
     fallbacks: {
         entries: [
             {
-                url: '/offline.html',
+                url: '/offline-fallback.html',
                 matcher({ request }) {
                     return request.destination === 'document';
                 },

--- a/src/components/pages/offline/OfflineActions.tsx
+++ b/src/components/pages/offline/OfflineActions.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+import Button from '@/components/ui/Button';
+import ResetIcon from '@/components/icons/reset';
+
+/**
+ * Offline page actions. "Try again" reloads the current URL (the page the user
+ * was actually trying to reach), so a restored connection resolves it directly
+ * instead of bouncing home. "Back home" is a plain link to a likely cached route.
+ */
+export default function OfflineActions() {
+    return (
+        <div className="mt-10 flex flex-wrap items-center gap-3">
+            <Button
+                type="button"
+                onClick={() => window.location.reload()}
+            >
+                <ResetIcon
+                    aria-hidden="true"
+                    className="size-4"
+                />
+                Try again
+            </Button>
+            <Link
+                href="/"
+                className="border-foreground/15 hover:bg-foreground/5 inline-flex items-center justify-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-semibold transition-colors"
+            >
+                Back home
+            </Link>
+        </div>
+    );
+}


### PR DESCRIPTION
Split the offline experience into two pages:

- New /offline Next route (src/app/offline) built from the real site chrome (navbar, footer, theme switcher via the root layout), so it matches the site and is viewable in dev and prod. noindex, kept out of the sitemap and navbar.
- Keep the minimal, script-free page as the service worker navigation fallback, renamed public/offline.html -> public/offline-fallback.html to free the /offline.html export path for the route and avoid the static-export path collision. A hydrated route cannot be the fallback: served under an arbitrary offline URL it reruns the client router and renders not-found.

Repoint sw.ts fallbacks.entries at /offline-fallback.html.