### PR TITLE
fix(pwa): drop hashed _next assets from precache to stop install 404s

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,6 +49,23 @@ const withSerwist = withSerwistInit({
     disable: isDev,
     register: false,
     reloadOnOnline: false,
+    // Keep content-hashed build output out of the precache. Every redeploy
+    // replaces the entire /_next/static tree (buildId-scoped _ssgManifest.js /
+    // _buildManifest.js, route chunks, css, fonts) with new hashes, so a client
+    // installing a service worker whose manifest still lists a previous build's
+    // assets hits 404s. Serwist precaching is all-or-nothing, so one 404 fails
+    // the whole install (bad-precaching-response) and the new worker never takes
+    // over. Precaching only deploy-stable public assets (offline-fallback.html,
+    // icons, images) keeps install resilient across builds; the runtimeCaching
+    // rules in src/app/sw.ts serve /_next assets on demand and tolerate 404s.
+    manifestTransforms: [
+        (entries) => ({
+            manifest: entries.filter(
+                (entry) => !entry.url.startsWith('/_next/static/')
+            ),
+            warnings: [],
+        }),
+    ],
 });
 
 export default withSerwist(nextConfig);

--- a/src/components/pwa/ServiceWorkerManager/hooks/useServiceWorker.ts
+++ b/src/components/pwa/ServiceWorkerManager/hooks/useServiceWorker.ts
@@ -14,9 +14,9 @@ const PRECACHE_NAME_MARKER = 'serwist-precache';
  * Delete the runtime caches (visited pages, static assets, images) while
  * preserving the Serwist precache. Called when an update takes over so a
  * stable-URL asset that changed in place (e.g. an image reused under the same
- * filename) is refetched fresh, without dropping /offline.html and the app
- * shell, which live in the precache and must stay available offline. The
- * emptied runtime caches repopulate on demand as pages/assets are fetched again.
+ * filename) is refetched fresh, without dropping /offline-fallback.html and the
+ * other precached public assets, which must stay available offline. The emptied
+ * runtime caches repopulate on demand as pages/assets are fetched again.
  */
 async function clearRuntimeCaches(): Promise<void> {
     if (typeof window === 'undefined' || !('caches' in window)) return;
@@ -73,9 +73,10 @@ export function useServiceWorker(): ServiceWorkerState {
         // When the waiting worker takes control after skipWaiting, drop the
         // runtime caches (so a changed stable-URL asset is refetched fresh) but
         // keep the Serwist precache, then reload once. Never clear everything:
-        // the precache holds /offline.html and the app shell, and the already
-        // installed worker will not re-run its precache install step, so wiping
-        // it would break offline access until the next deploy.
+        // the precache holds /offline-fallback.html and the other precached
+        // public assets, and the already installed worker will not re-run its
+        // precache install step, so wiping it would break the offline fallback
+        // until the next deploy.
         let hasReloaded = false;
         const onControlling = async () => {
             if (hasReloaded) return;


### PR DESCRIPTION
Serwist precaching is all-or-nothing, so a single 404 fails the whole service worker install (bad-precaching-response) and the new worker never activates. The precache manifest included the content-hashed /_next/static build output (buildId-scoped _ssgManifest.js / _buildManifest.js, route chunks, css, fonts). Every redeploy replaces that tree with new hashes and deletes the old files, so any client installing a worker whose manifest still lists a previous build's assets hits 404s. GitHub Pages replaces out/ wholesale each deploy and cannot retain old builds, so this is structural, not a missing-file bug.

Filter /_next/static/** out of the injected manifest via manifestTransforms. Precache now holds only deploy-stable public assets (offline-fallback.html, icons, images) whose URLs survive a redeploy, so install stays resilient across builds. The runtimeCaching rules already serve /_next assets on demand and tolerate 404s without failing install.

Also update the ServiceWorkerManager comments to match: the preserved precache holds the offline fallback and public assets, not the JS shell.