### PR TITLE
feat(offline): bolder "lost signal" hero for the offline page

### DIFF
--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,5 +1,4 @@
-import SectionHeading from '@/components/pages/common/SectionHeading';
-import OfflineActions from '@/components/pages/offline/OfflineActions';
+import OfflineStage from '@/components/pages/offline/OfflineStage';
 import { siteName } from '@/config/constants';
 import { buildPageMetadata } from '@/utils/pageMetadata';
 
@@ -14,38 +13,5 @@ export const metadata = buildPageMetadata({
 });
 
 export default function OfflinePage() {
-    return (
-        <main className="relative container mx-auto flex grow flex-col items-center justify-center overflow-hidden px-4 py-20 text-center sm:py-28">
-            {/* Faint display-face watermark behind the message, purely decorative. */}
-            <span
-                aria-hidden="true"
-                className="text-foreground/[0.04] font-display pointer-events-none absolute inset-x-0 top-1/2 -z-10 -translate-y-1/2 text-[28vw] leading-none font-black tracking-tighter select-none"
-            >
-                Offline
-            </span>
-
-            <span className="border-foreground/10 bg-background/60 text-foreground/70 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium backdrop-blur-lg">
-                <span
-                    aria-hidden="true"
-                    className="size-2 rounded-full bg-amber-500 motion-safe:animate-pulse"
-                />
-                No connection
-            </span>
-
-            <SectionHeading
-                as="h1"
-                className="mt-6"
-            >
-                You are offline
-            </SectionHeading>
-
-            <p className="text-foreground/70 mt-5 max-w-xl text-lg leading-relaxed text-balance">
-                Looks like your connection dropped. This page has not been saved
-                for offline reading yet. Reconnect and try again, or head back to
-                a page you have already visited.
-            </p>
-
-            <OfflineActions />
-        </main>
-    );
+    return <OfflineStage />;
 }

--- a/src/components/pages/offline/OfflineStage/OfflineStage.module.css
+++ b/src/components/pages/offline/OfflineStage/OfflineStage.module.css
@@ -1,0 +1,30 @@
+@reference "tailwindcss";
+
+/* Amber accent bloom resting behind the offline hero, following the site's
+   signature glow motif (SkillCard / SignatureSpotlight). This is a section-level
+   surface rather than a hoverable card, so the glow rests soft and steady (no
+   hover bloom) and steps up a touch in dark mode, mirroring the token rules. The
+   radial gradient + color-mix are the sanctioned raw-CSS exceptions. */
+.stage {
+    --offline-glow: 9%;
+}
+
+@media (prefers-color-scheme: dark) {
+    :global(html:not([data-theme])) .stage {
+        --offline-glow: 15%;
+    }
+}
+:global(html[data-theme='dark']) .stage {
+    --offline-glow: 15%;
+}
+
+/* Sits behind the grid (which is -z-10) so the wash tints the grid in the
+   centre; page content stays above at the default stacking level. */
+.stage::before {
+    @apply pointer-events-none absolute inset-0 content-[''] [z-index:-20];
+    background-image: radial-gradient(
+        60% 45% at 50% 42%,
+        color-mix(in oklab, var(--color-amber-500) var(--offline-glow), transparent),
+        transparent 70%
+    );
+}

--- a/src/components/pages/offline/OfflineStage/index.tsx
+++ b/src/components/pages/offline/OfflineStage/index.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/utils/cn';
+import GridBackground from '@/components/backgrounds/GridBackground';
+import SignalRings from '@/components/pages/offline/SignalRings';
+import OfflineActions from '@/components/pages/offline/OfflineActions';
+import { zain } from '@/config/fonts';
+import styles from '@/components/pages/offline/OfflineStage/OfflineStage.module.css';
+
+/**
+ * The offline hero: a "lost signal" stage that echoes the home hero (grid
+ * backdrop + display type) with an amber accent. Everything here is CSS-driven,
+ * so it renders and animates identically in the script-stripped offline fallback
+ * snapshot (see scripts/generate-offline-fallback.ts). The only scripted bit is
+ * OfflineActions' reload, which the snapshot rewires via `data-offline-reload`.
+ */
+export default function OfflineStage() {
+    return (
+        <main
+            className={cn(
+                styles.stage,
+                zain.variable,
+                'relative isolate flex grow flex-col items-center justify-center overflow-hidden px-4 py-20 text-center'
+            )}
+        >
+            <GridBackground className="opacity-60" />
+
+            <SignalRings />
+
+            <span className="border-foreground/10 bg-background/60 text-foreground/70 mt-8 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium backdrop-blur-sm">
+                <span
+                    aria-hidden="true"
+                    className="size-2 rounded-full bg-amber-500 motion-safe:animate-pulse"
+                />
+                No connection
+            </span>
+
+            <h1 className="font-display mt-6 text-[length:clamp(3.5rem,17vw,9rem)] leading-[0.82] font-bold tracking-tight">
+                Offline
+            </h1>
+
+            <p className="text-foreground/70 mt-6 max-w-xl text-lg leading-relaxed text-balance">
+                You have slipped off the grid. This page was not saved for
+                offline reading, so reconnect to load it, or head back to
+                somewhere you have already been.
+            </p>
+
+            <OfflineActions />
+        </main>
+    );
+}

--- a/src/components/pages/offline/SignalRings/SignalRings.module.css
+++ b/src/components/pages/offline/SignalRings/SignalRings.module.css
@@ -1,0 +1,55 @@
+@reference "tailwindcss";
+
+/* Radar "searching for signal" glyph. Everything expressible as a utility uses
+   @apply; the amber tint (color-mix) and the pulse keyframes are the sanctioned
+   raw-CSS exceptions. The rings and core share the amber signal colour that also
+   drives the "No connection" status dot, keeping the offline accent consistent. */
+.radar {
+    @apply size-28 sm:size-32;
+    --signal: var(--color-amber-500);
+}
+
+/* A persistent faint target ring so the glyph reads even at rest (a still frame
+   or reduced motion), under the outward pulses. */
+.halo {
+    @apply absolute size-2/3 rounded-full border opacity-30 content-[''];
+    border-color: color-mix(in oklab, var(--signal) 55%, transparent);
+}
+
+.ring {
+    @apply absolute size-full rounded-full border content-[''];
+    border-color: color-mix(in oklab, var(--signal) 45%, transparent);
+    /* Reduced-motion / no-animation resting state: one faint static ring. */
+    @apply opacity-40;
+    /* With motion allowed, the rings start collapsed and transparent and the
+       keyframes drive the outward pulse. */
+    @apply motion-safe:animate-[radar-pulse_2.8s_ease-out_infinite] motion-safe:opacity-0;
+}
+
+.ring:nth-child(2) {
+    @apply motion-safe:[animation-delay:0.93s];
+}
+
+.ring:nth-child(3) {
+    @apply motion-safe:[animation-delay:1.86s];
+}
+
+.core {
+    @apply absolute size-3 rounded-full;
+    background-color: var(--signal);
+    box-shadow: 0 0 0 6px color-mix(in oklab, var(--signal) 22%, transparent);
+}
+
+@keyframes radar-pulse {
+    0% {
+        transform: scale(0.16);
+        opacity: 0.7;
+    }
+    80% {
+        opacity: 0;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 0;
+    }
+}

--- a/src/components/pages/offline/SignalRings/index.tsx
+++ b/src/components/pages/offline/SignalRings/index.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/cn';
+import styles from '@/components/pages/offline/SignalRings/SignalRings.module.css';
+
+/**
+ * "Searching for signal" radar glyph: a solid core node with concentric rings
+ * that pulse outward and fade, evoking a device reaching for a network that is
+ * not there. Pure CSS so it also animates inside the script-stripped offline
+ * fallback snapshot; it collapses to a single static ring under reduced motion.
+ */
+export default function SignalRings() {
+    return (
+        <div
+            aria-hidden="true"
+            className={cn(styles.radar, 'relative grid place-items-center')}
+        >
+            <span className={styles.halo} />
+            <span className={styles.ring} />
+            <span className={styles.ring} />
+            <span className={styles.ring} />
+            <span className={styles.core} />
+        </div>
+    );
+}


### PR DESCRIPTION
Redesign /offline from the plain centered message into a hero that echoes the home page: a grid backdrop (GridBackground), a giant display-face "Offline", and an amber accent that ties together an animated radar glyph, a resting accent bloom, and the "No connection" status dot.

- SignalRings: amber core + persistent target ring + three outward pulsing rings (CSS keyframes, motion-safe, collapses to a static ring under reduced motion).
- OfflineStage: grid background, section-level amber bloom (::before, stepped up in dark), display headline, copy, and OfflineActions.
- page.tsx is now thin (metadata + <OfflineStage />).

Everything is CSS-driven, so it renders and animates identically in the script-stripped offline fallback snapshot.