### PR TITLE
feat(pwa): always cache the home page for offline

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,20 +49,28 @@ const withSerwist = withSerwistInit({
     disable: isDev,
     register: false,
     reloadOnOnline: false,
-    // Keep content-hashed build output out of the precache. Every redeploy
-    // replaces the entire /_next/static tree (buildId-scoped _ssgManifest.js /
-    // _buildManifest.js, route chunks, css, fonts) with new hashes, so a client
-    // installing a service worker whose manifest still lists a previous build's
-    // assets hits 404s. Serwist precaching is all-or-nothing, so one 404 fails
-    // the whole install (bad-precaching-response) and the new worker never takes
-    // over. Precaching only deploy-stable public assets (offline-fallback.html,
-    // icons, images) keeps install resilient across builds; the runtimeCaching
-    // rules in src/app/sw.ts serve /_next assets on demand and tolerate 404s.
+    // Precache the home document so `/` is always available offline. Serwist
+    // precaches the /_next build assets (the app shell) but not the exported HTML
+    // pages (in this static export they are not globbed), and the runtime
+    // navigation cache is wiped on every update (see clearRuntimeCaches in
+    // useServiceWorker), so without this the home page drops out of the offline
+    // cache after an update until it is revisited. The precache survives updates,
+    // so the shell plus this entry keep `/` fully interactive offline.
+    //
+    // Appended via manifestTransforms (not additionalPrecacheEntries, which in
+    // this @serwist/next version replaces the whole globbed manifest and drops
+    // the public assets + offline-fallback.html). The transform runs on the final
+    // URLs, so it just adds `/`, de-duping in case a future export ever globs
+    // index.html. `buildTime` changes every build, so the entry re-caches on each
+    // deploy; `/` always exists, so it never 404s. Cross-build install 404s from
+    // the hashed shell assets are prevented by updateViaCache 'none' on the client
+    // (always fetch a fresh, in-step sw.js).
     manifestTransforms: [
         (entries) => ({
-            manifest: entries.filter(
-                (entry) => !entry.url.startsWith('/_next/static/')
-            ),
+            manifest: [
+                ...entries.filter((entry) => entry.url !== '/'),
+                { url: '/', revision: buildTime, size: 0 },
+            ],
             warnings: [],
         }),
     ],

--- a/src/components/pwa/ServiceWorkerManager/hooks/useServiceWorker.ts
+++ b/src/components/pwa/ServiceWorkerManager/hooks/useServiceWorker.ts
@@ -14,9 +14,10 @@ const PRECACHE_NAME_MARKER = 'serwist-precache';
  * Delete the runtime caches (visited pages, static assets, images) while
  * preserving the Serwist precache. Called when an update takes over so a
  * stable-URL asset that changed in place (e.g. an image reused under the same
- * filename) is refetched fresh, without dropping /offline-fallback.html and the
- * other precached public assets, which must stay available offline. The emptied
- * runtime caches repopulate on demand as pages/assets are fetched again.
+ * filename) is refetched fresh, without dropping the precache: the app shell,
+ * the home document (`/`), and /offline-fallback.html live there and must stay
+ * available offline. The emptied runtime caches repopulate on demand as
+ * pages/assets are fetched again.
  */
 async function clearRuntimeCaches(): Promise<void> {
     if (typeof window === 'undefined' || !('caches' in window)) return;
@@ -64,7 +65,17 @@ export function useServiceWorker(): ServiceWorkerState {
             return;
         }
 
-        const serwist = new Serwist('/sw.js', { scope: '/' });
+        // updateViaCache: 'none' makes the browser bypass the HTTP cache when
+        // fetching sw.js (and its imports) on every update check. The deploy
+        // serves sw.js with a multi-hour max-age, so without this a client could
+        // install a stale sw.js whose precache manifest lists a previous build's
+        // content-hashed assets (already deleted by a newer deploy) and fail the
+        // whole install with bad-precaching-response. Always fetching a fresh
+        // sw.js keeps the manifest in step with the live assets.
+        const serwist = new Serwist('/sw.js', {
+            scope: '/',
+            updateViaCache: 'none',
+        });
         serwistRef.current = serwist;
 
         const onWaiting = () => setUpdateReady(true);
@@ -73,10 +84,10 @@ export function useServiceWorker(): ServiceWorkerState {
         // When the waiting worker takes control after skipWaiting, drop the
         // runtime caches (so a changed stable-URL asset is refetched fresh) but
         // keep the Serwist precache, then reload once. Never clear everything:
-        // the precache holds /offline-fallback.html and the other precached
-        // public assets, and the already installed worker will not re-run its
-        // precache install step, so wiping it would break the offline fallback
-        // until the next deploy.
+        // the precache holds the app shell, the home document, and
+        // /offline-fallback.html, and the already installed worker will not
+        // re-run its precache install step, so wiping it would break offline
+        // access until the next deploy.
         let hasReloaded = false;
         const onControlling = async () => {
             if (hasReloaded) return;


### PR DESCRIPTION
The home document was only ever in the runtime navigation cache, which clearRuntimeCaches wipes on every update, so after an update the home page was unavailable offline until revisited. Precache it instead (survives updates) and restore the app shell to the precache so offline home is fully interactive.

- Append `/` (revision = buildTime) to the precache via manifestTransforms so the home document is always precached. Not additionalPrecacheEntries: in this @serwist/next version that option replaces the whole globbed manifest and drops the public assets and offline-fallback.html.
- Stop excluding /_next from the precache (revert the earlier filter) so the home page's chunks and css are available offline.
- Set updateViaCache: 'none' on the client registration. This is the root-cause fix for the earlier bad-precaching-response: the browser now always fetches a fresh sw.js (bypassing the multi-hour CDN cache on it), so a client can no longer install a stale worker whose manifest lists a previous build's deleted, content-hashed assets.

Verified offline (headless Chromium over CDP, server killed for a real offline): with the runtime caches cleared to mimic the post-update state, `/` still renders the full home page from precache, and an unvisited URL falls back to the offline page.