### PR TITLE
feat(offline): brand the minimal offline fallback

### DIFF
--- a/public/offline-fallback.html
+++ b/public/offline-fallback.html
@@ -6,30 +6,39 @@
         <meta name="robots" content="noindex" />
         <title>Offline | Shibbir Ahmed</title>
         <!--
-            The minimal, last-resort offline fallback. Served by the service
-            worker as the navigation fallback when an unvisited page is opened
-            with no network. Deliberately a plain, script-free, self-contained
-            static file (not a Next route): a Next page served under an arbitrary
-            URL would re-run the client router and render not-found, clobbering
-            this message, so the styled /offline route (src/app/offline) cannot
-            play this role. That route is the primary, full-design offline page
-            (navbar, footer, theme switcher); this file only has to survive with
-            zero dependencies at any URL.
+            The minimal, last-resort offline fallback, branded as Shibbir Ahmed.
+            Served by the service worker as the navigation fallback when an
+            unvisited page is opened with no network. Deliberately a plain,
+            script-free, self-contained static file (not a Next route): a Next
+            page served under an arbitrary URL would re-run the client router and
+            render not-found, clobbering this message.
+
+            In production the build (scripts/generate-offline-fallback.ts)
+            overwrites the served copy with a script-stripped snapshot of the
+            /offline route, so visitors get the full site chrome. This committed
+            file is the precache placeholder, what dev serves, and the graceful
+            fallback if that snapshot step ever fails, so it stays on-brand on
+            its own.
         -->
         <style>
             :root {
                 color-scheme: light dark;
-                --bg: #ffffff;
+                --bg: #ededed;
                 --fg: #171717;
                 --muted: #171717a6;
-                --border: #17171733;
+                --border: #17171722;
+                --amber: #f59e0b;
+                --grid: #7373731f;
+                --bloom: rgba(245, 158, 11, 0.1);
             }
             @media (prefers-color-scheme: dark) {
                 :root {
                     --bg: #0a0a0a;
                     --fg: #ededed;
                     --muted: #edededa6;
-                    --border: #ededed33;
+                    --border: #ededed1f;
+                    --grid: #7373732b;
+                    --bloom: rgba(245, 158, 11, 0.16);
                 }
             }
             * {
@@ -40,26 +49,108 @@
                 min-height: 100svh;
                 display: flex;
                 flex-direction: column;
-                align-items: center;
-                justify-content: center;
-                gap: 1rem;
-                padding: 2rem 1rem;
-                text-align: center;
                 background: var(--bg);
                 color: var(--fg);
                 font-family:
                     ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
                     sans-serif;
             }
-            .badge {
-                font-size: clamp(3rem, 8vw, 4.5rem);
-                font-weight: 700;
+            /* Grid + amber bloom backdrop, masked to a soft ellipse so it fades
+               at the edges (echoes the site's GridBackground / offline hero). */
+            body::before {
+                content: '';
+                position: fixed;
+                inset: 0;
+                z-index: -1;
+                background-image:
+                    radial-gradient(
+                        55% 45% at 50% 42%,
+                        var(--bloom),
+                        transparent 70%
+                    ),
+                    linear-gradient(to right, var(--grid) 1px, transparent 1px),
+                    linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
+                background-size:
+                    100% 100%,
+                    22px 22px,
+                    22px 22px;
+                -webkit-mask-image: radial-gradient(
+                    ellipse 60% 60% at 50% 45%,
+                    #000 55%,
+                    transparent 100%
+                );
+                mask-image: radial-gradient(
+                    ellipse 60% 60% at 50% 45%,
+                    #000 55%,
+                    transparent 100%
+                );
+            }
+            .brand {
+                align-self: center;
+                display: inline-flex;
+                padding: 1.5rem;
                 color: var(--muted);
-                line-height: 1;
+                transition: color 0.2s ease;
+            }
+            .brand:hover {
+                color: var(--fg);
+            }
+            .brand svg {
+                height: 18px;
+                width: auto;
+                display: block;
+            }
+            main {
+                flex: 1;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                gap: 1.25rem;
+                padding: 1rem 1.5rem 4rem;
+                text-align: center;
+            }
+            .status {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                padding: 0.4rem 0.9rem;
+                border: 1px solid var(--border);
+                border-radius: 9999px;
+                font-size: 0.875rem;
+                font-weight: 500;
+                color: var(--muted);
+            }
+            .dot {
+                width: 0.5rem;
+                height: 0.5rem;
+                border-radius: 9999px;
+                background: var(--amber);
+                box-shadow: 0 0 0 0 var(--bloom);
+                animation: signal 2.2s ease-out infinite;
+            }
+            @media (prefers-reduced-motion: reduce) {
+                .dot {
+                    animation: none;
+                }
+            }
+            @keyframes signal {
+                0% {
+                    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.5);
+                }
+                70% {
+                    box-shadow: 0 0 0 0.6rem rgba(245, 158, 11, 0);
+                }
+                100% {
+                    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0);
+                }
             }
             h1 {
-                margin: 0.5rem 0 0;
-                font-size: clamp(1.5rem, 4vw, 2rem);
+                margin: 0;
+                font-size: clamp(3rem, 15vw, 6.5rem);
+                font-weight: 800;
+                letter-spacing: -0.03em;
+                line-height: 0.9;
             }
             p {
                 margin: 0;
@@ -68,31 +159,66 @@
                 font-size: 1.05rem;
                 line-height: 1.6;
             }
-            a {
-                margin-top: 1rem;
+            a.action {
+                margin-top: 0.5rem;
                 display: inline-block;
                 padding: 0.75rem 1.5rem;
                 border: 1px solid var(--border);
                 border-radius: 9999px;
                 color: inherit;
                 text-decoration: none;
+                font-weight: 600;
+                font-size: 0.9rem;
                 transition:
                     transform 0.2s ease,
                     border-color 0.2s ease;
             }
-            a:hover {
-                transform: scale(1.05);
+            a.action:hover {
+                transform: scale(1.04);
                 border-color: var(--fg);
             }
         </style>
     </head>
     <body>
-        <p class="badge">Offline</p>
-        <h1>You are offline</h1>
-        <p>
-            This page has not been saved for offline reading yet. Reconnect to
-            load it, or head back to a page you have already visited.
-        </p>
-        <a href="/">Back home</a>
+        <a
+            class="brand"
+            href="/"
+            aria-label="Shibbir Ahmed, home"
+        >
+            <svg
+                viewBox="0 0 588.6 82.601"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                style="overflow: visible"
+            >
+                <path
+                    fill="currentColor"
+                    stroke="currentColor"
+                    fill-rule="evenodd"
+                    vector-effect="non-scaling-stroke"
+                    d="M 449.3 81.7 L 440.1 81.7 L 441.6 0.7 L 452.7 0.7 L 467 66.4 L 481.4 0.7 L 492.4 0.7 L 493.9 81.7 L 484.8 81.7 L 483.9 22.9 L 470.2 81.7 L 463.8 81.7 L 450.2 22.9 L 449.3 81.7 Z M 61 81.7 L 49.7 81.7 L 49.7 0.7 L 61 0.7 L 61 35.7 L 81.8 35.7 L 81.8 0.7 L 93.1 0.7 L 93.1 81.7 L 81.8 81.7 L 81.8 43.8 L 61 43.8 L 61 81.7 Z M 395.5 81.7 L 384.2 81.7 L 384.2 0.7 L 395.5 0.7 L 395.5 35.7 L 416.3 35.7 L 416.3 0.7 L 427.6 0.7 L 427.6 81.7 L 416.3 81.7 L 416.3 43.8 L 395.5 43.8 L 395.5 81.7 Z M 0 59 L 10 56.3 Q 10.3 60.6 11.35 64.6 Q 12.4 68.6 14.8 71.15 Q 17.2 73.7 21.5 73.7 Q 25.9 73.7 28.15 71.25 Q 30.4 68.8 30.4 64.2 Q 30.4 58.7 27.9 55.35 Q 25.4 52 21.6 48.6 L 8 36.6 Q 4 33.1 2.1 28.95 Q 0.2 24.8 0.2 18.7 Q 0.2 9.8 5.3 4.9 Q 10.4 0 19.2 0 Q 24 0 27.65 1.25 Q 31.3 2.5 33.75 5.1 Q 36.2 7.7 37.65 11.65 Q 39.1 15.6 39.6 20.9 L 30 23.5 Q 29.7 19.5 28.8 16.15 Q 27.9 12.8 25.65 10.75 Q 23.4 8.7 19.2 8.7 Q 15 8.7 12.65 10.95 Q 10.3 13.2 10.3 17.6 Q 10.3 21.3 11.55 23.7 Q 12.8 26.1 15.6 28.6 L 29.3 40.6 Q 33.9 44.6 37.4 50.15 Q 40.9 55.7 40.9 63.3 Q 40.9 69.3 38.4 73.65 Q 35.9 78 31.55 80.3 Q 27.2 82.6 21.5 82.6 Q 14.5 82.6 9.85 79.6 Q 5.2 76.6 2.8 71.3 Q 0.4 66 0 59 Z M 271.5 81.7 L 260.2 81.7 L 260.2 0.7 L 276.5 0.7 Q 284.6 0.7 289.9 2.85 Q 295.2 5 297.75 9.75 Q 300.3 14.5 300.3 22.2 Q 300.3 26.9 299.3 30.75 Q 298.3 34.6 296.1 37.25 Q 293.9 39.9 290.3 41.1 L 301.8 81.7 L 290.9 81.7 L 280.3 43.7 L 271.5 43.7 L 271.5 81.7 Z M 537.9 81.7 L 506.3 81.7 L 506.3 0.7 L 537.7 0.7 L 537.7 9.1 L 517.6 9.1 L 517.6 35.9 L 533.9 35.9 L 533.9 43.9 L 517.6 43.9 L 517.6 73.6 L 537.9 73.6 L 537.9 81.7 Z M 341.2 81.7 L 330.6 81.7 L 347.8 0.7 L 358.7 0.7 L 376 81.7 L 365.3 81.7 L 361.6 61.3 L 345.1 61.3 L 341.2 81.7 Z M 152.2 81.7 L 130.6 81.7 L 130.6 0.7 L 149.2 0.7 Q 154.7 0.7 158.75 1.9 Q 162.8 3.1 165.5 5.6 Q 168.2 8.1 169.5 11.95 Q 170.8 15.8 170.8 21 Q 170.8 26 169.55 29.65 Q 168.3 33.3 165.75 35.4 Q 163.2 37.5 159.2 38.1 Q 164.1 39.2 167.1 41.85 Q 170.1 44.5 171.55 48.65 Q 173 52.8 173 58.6 Q 173 63.8 171.8 68.1 Q 170.6 72.4 168.05 75.4 Q 165.5 78.4 161.55 80.05 Q 157.6 81.7 152.2 81.7 Z M 204.6 81.7 L 183 81.7 L 183 0.7 L 201.6 0.7 Q 207.1 0.7 211.15 1.9 Q 215.2 3.1 217.9 5.6 Q 220.6 8.1 221.9 11.95 Q 223.2 15.8 223.2 21 Q 223.2 26 221.95 29.65 Q 220.7 33.3 218.15 35.4 Q 215.6 37.5 211.6 38.1 Q 216.5 39.2 219.5 41.85 Q 222.5 44.5 223.95 48.65 Q 225.4 52.8 225.4 58.6 Q 225.4 63.8 224.2 68.1 Q 223 72.4 220.45 75.4 Q 217.9 78.4 213.95 80.05 Q 210 81.7 204.6 81.7 Z M 565.5 81.7 L 547 81.7 L 547 0.7 L 564.6 0.7 Q 573.6 0.7 578.85 3.45 Q 584.1 6.2 586.35 11.7 Q 588.6 17.2 588.6 25.4 L 588.6 55.2 Q 588.6 63.8 586.35 69.7 Q 584.1 75.6 579.05 78.65 Q 574 81.7 565.5 81.7 Z M 117.5 81.7 L 106.4 81.7 L 106.4 0.7 L 117.5 0.7 L 117.5 81.7 Z M 247.1 81.7 L 236 81.7 L 236 0.7 L 247.1 0.7 L 247.1 81.7 Z M 558.3 9.1 L 558.3 73.6 L 564.7 73.6 Q 570.9 73.6 573.5 71.2 Q 576.1 68.8 576.65 64.2 Q 577.2 59.6 577.2 53.1 L 577.2 26.8 Q 577.2 20.5 576.4 16.6 Q 575.6 12.7 572.9 10.9 Q 570.2 9.1 564.4 9.1 L 558.3 9.1 Z M 141.9 43.1 L 141.9 73.6 L 149.5 73.6 Q 157.1 73.6 159.65 70.05 Q 162.2 66.5 162.2 58.6 Q 162.2 53.5 160.85 50.05 Q 159.5 46.6 156.55 44.85 Q 153.6 43.1 148.6 43.1 L 141.9 43.1 Z M 194.3 43.1 L 194.3 73.6 L 201.9 73.6 Q 209.5 73.6 212.05 70.05 Q 214.6 66.5 214.6 58.6 Q 214.6 53.5 213.25 50.05 Q 211.9 46.6 208.95 44.85 Q 206 43.1 201 43.1 L 194.3 43.1 Z M 353.3 16.7 L 346.6 53.2 L 360.1 53.2 L 353.3 16.7 Z M 141.9 9.1 L 141.9 34.5 L 148.6 34.5 Q 153.4 34.5 156.1 33.15 Q 158.8 31.8 159.9 28.8 Q 161 25.8 161 21 Q 161 15.4 159.3 12.9 Q 157.6 10.4 154 9.75 Q 150.4 9.1 144.6 9.1 L 141.9 9.1 Z M 194.3 9.1 L 194.3 34.5 L 201 34.5 Q 205.8 34.5 208.5 33.15 Q 211.2 31.8 212.3 28.8 Q 213.4 25.8 213.4 21 Q 213.4 15.4 211.7 12.9 Q 210 10.4 206.4 9.75 Q 202.8 9.1 197 9.1 L 194.3 9.1 Z M 271.5 8.8 L 271.5 35.6 L 275.8 35.6 Q 280.6 35.6 283.6 34.4 Q 286.6 33.2 288 30.3 Q 289.4 27.4 289.4 22.2 Q 289.4 15.1 286.8 11.95 Q 284.2 8.8 276.5 8.8 L 271.5 8.8 Z"
+                />
+            </svg>
+        </a>
+        <main>
+            <span class="status">
+                <span
+                    class="dot"
+                    aria-hidden="true"
+                ></span>
+                No connection
+            </span>
+            <h1>Offline</h1>
+            <p>
+                You have slipped off the grid. This page was not saved for
+                offline reading, so reconnect to load it, or head back to
+                somewhere you have already been.
+            </p>
+            <a
+                class="action"
+                href="/"
+                >Back home</a
+            >
+        </main>
     </body>
 </html>


### PR DESCRIPTION
Redesign public/offline-fallback.html (the precache placeholder that dev serves and the graceful fallback if the /offline snapshot step fails) to match the site: a centered SHIBBIR AHMED wordmark, a grid + amber bloom backdrop, a "No connection" pill with a pulsing signal dot, a bold "Offline", and the "slipped off the grid" copy. Stays self-contained, script-free, and light/dark aware via prefers-color-scheme, so it holds up on its own at any URL.