### PR TITLE
feat(offline): react to the connection returning

### DIFF
--- a/scripts/generate-offline-fallback.ts
+++ b/scripts/generate-offline-fallback.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { THEME_STORAGE_KEY } from '@/components/layout/ThemeToggle/theme';
+import { OFFLINE_RECONNECT_SCRIPT } from '@/components/pages/offline/offlineReconnect';
 
 const OUT = path.join(process.cwd(), 'out');
 const SOURCE = path.join(OUT, 'offline.html');
@@ -31,8 +32,11 @@ const themePrePaintScript = `<script>(function(){try{var p=localStorage.getItem(
     THEME_STORAGE_KEY
 )});var t=(p==='light'||p==='dark')?p:(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');var d=document.documentElement;d.setAttribute('data-theme',t);d.style.colorScheme=t;}catch(e){}})();</script>`;
 
-// Keep the one interactive affordance that is cheap without hydration: reload.
-const tryAgainScript = `<script>document.addEventListener('click',function(e){var t=e.target.closest('[data-offline-reload]');if(t){e.preventDefault();location.reload();}});</script>`;
+// The offline reconnect behaviour (network listener, amber -> emerald swap,
+// auto-reload countdown, and the "Try again" reload). Shared verbatim with the
+// /offline route (OfflineStage renders the same source inline), so the fallback
+// snapshot behaves identically once its scripts are stripped.
+const reconnectScript = `<script>${OFFLINE_RECONNECT_SCRIPT}</script>`;
 
 function inlineStylesheet(tag: string): string {
     const href = tag.match(/href="([^"]+)"/)?.[1];
@@ -64,11 +68,12 @@ function main(): void {
         .replace(/<link\b[^>]*rel="preload"[^>]*>/gi, '')
         .replace(/<link\b[^>]*rel="stylesheet"[^>]*>/gi, inlineStylesheet);
 
-    // 3. Re-add the pre-paint theme script and the reload handler.
-    html = html.replace(
-        '</head>',
-        `${themePrePaintScript}${tryAgainScript}</head>`
-    );
+    // 3. Re-add the pre-paint theme script in <head> (it only touches
+    //    documentElement), and the reconnect script at the end of <body> (it needs
+    //    the offline markup to exist when it runs).
+    html = html
+        .replace('</head>', `${themePrePaintScript}</head>`)
+        .replace('</body>', `${reconnectScript}</body>`);
 
     fs.writeFileSync(DESTINATION, html);
 

--- a/src/components/pages/offline/OfflineActions.tsx
+++ b/src/components/pages/offline/OfflineActions.tsx
@@ -1,23 +1,19 @@
-'use client';
-
 import Link from 'next/link';
 import Button from '@/components/ui/Button';
 import ResetIcon from '@/components/icons/reset';
 
 /**
  * Offline page actions. "Try again" reloads the current URL (the page the user
- * was actually trying to reach), so a restored connection resolves it directly
- * instead of bouncing home. "Back home" is a plain link to a likely cached route.
+ * was actually trying to reach) via the delegated `data-offline-reload` handler
+ * in OFFLINE_RECONNECT_SCRIPT, so it works on both the hydrated route and the
+ * script-stripped fallback snapshot without its own client bundle. "Back home"
+ * links to the (precached) home page.
  */
 export default function OfflineActions() {
     return (
-        <div className="mt-10 flex flex-wrap items-center gap-3">
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
             <Button
                 type="button"
-                onClick={() => window.location.reload()}
-                // Also targeted by the static offline-fallback snapshot's reload
-                // handler, which runs when hydration is stripped (the onClick is
-                // gone there). See scripts/generate-offline-fallback.ts.
                 data-offline-reload
             >
                 <ResetIcon

--- a/src/components/pages/offline/OfflineStage/OfflineStage.module.css
+++ b/src/components/pages/offline/OfflineStage/OfflineStage.module.css
@@ -1,12 +1,27 @@
 @reference "tailwindcss";
 
-/* Amber accent bloom resting behind the offline hero, following the site's
-   signature glow motif (SkillCard / SignatureSpotlight). This is a section-level
-   surface rather than a hoverable card, so the glow rests soft and steady (no
-   hover bloom) and steps up a touch in dark mode, mirroring the token rules. The
-   radial gradient + color-mix are the sanctioned raw-CSS exceptions. */
+/* Registered so the amber -> emerald accent swap can be transitioned: it animates
+   the color-mix() bloom, the radar rings, and the status dot together (a plain
+   custom property cannot be transitioned). Inherited so SignalRings, a descendant,
+   picks it up. */
+@property --offline-accent {
+    syntax: '<color>';
+    inherits: true;
+    initial-value: #f59e0b;
+}
+
+/* The offline (default) accent is amber; the reconnect script flips data-status
+   to 'online', swapping to emerald, and the transition here animates the change.
+   The radial bloom + color-mix are the sanctioned raw-CSS exceptions. */
 .stage {
+    --offline-accent: var(--color-amber-500);
     --offline-glow: 9%;
+    @apply motion-safe:[transition:--offline-accent_700ms_ease];
+}
+
+.stage[data-status='online'] {
+    --offline-accent: var(--color-emerald-500);
+    --offline-glow: 12%;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,13 +33,51 @@
     --offline-glow: 15%;
 }
 
-/* Sits behind the grid (which is -z-10) so the wash tints the grid in the
-   centre; page content stays above at the default stacking level. */
+/* Sits behind the grid (which is -z-10) so the wash tints the grid in the centre;
+   page content stays above at the default stacking level. */
 .stage::before {
     @apply pointer-events-none absolute inset-0 content-[''] [z-index:-20];
     background-image: radial-gradient(
         60% 45% at 50% 42%,
-        color-mix(in oklab, var(--color-amber-500) var(--offline-glow), transparent),
+        color-mix(
+            in oklab,
+            var(--offline-accent) var(--offline-glow),
+            transparent
+        ),
         transparent 70%
     );
+}
+
+/* Status dot: the accent colour with a soft outward signal pulse. */
+.dot {
+    background-color: var(--offline-accent);
+    @apply motion-safe:animate-[offline-signal_2.2s_ease-out_infinite];
+}
+
+@keyframes offline-signal {
+    0% {
+        box-shadow: 0 0 0 0
+            color-mix(in oklab, var(--offline-accent) 50%, transparent);
+    }
+    70% {
+        box-shadow: 0 0 0 0.5rem
+            color-mix(in oklab, var(--offline-accent) 0%, transparent);
+    }
+    100% {
+        box-shadow: 0 0 0 0
+            color-mix(in oklab, var(--offline-accent) 0%, transparent);
+    }
+}
+
+/* Auto-reload control: only relevant once the connection is back, so it is hidden
+   until the reconnect script sets data-status='online'. */
+.autoReload {
+    @apply hidden;
+}
+.stage[data-status='online'] .autoReload {
+    @apply flex;
+}
+
+.checkbox {
+    accent-color: var(--offline-accent);
 }

--- a/src/components/pages/offline/OfflineStage/index.tsx
+++ b/src/components/pages/offline/OfflineStage/index.tsx
@@ -2,19 +2,37 @@ import { cn } from '@/utils/cn';
 import GridBackground from '@/components/backgrounds/GridBackground';
 import SignalRings from '@/components/pages/offline/SignalRings';
 import OfflineActions from '@/components/pages/offline/OfflineActions';
+import {
+    AUTO_RELOAD_LABEL,
+    OFFLINE_COPY,
+    OFFLINE_HEADING,
+    OFFLINE_RECONNECT_SCRIPT,
+    OFFLINE_STATUS,
+} from '@/components/pages/offline/offlineReconnect';
 import { zain } from '@/config/fonts';
 import styles from '@/components/pages/offline/OfflineStage/OfflineStage.module.css';
 
 /**
  * The offline hero: a "lost signal" stage that echoes the home hero (grid
- * backdrop + display type) with an amber accent. Everything here is CSS-driven,
- * so it renders and animates identically in the script-stripped offline fallback
- * snapshot (see scripts/generate-offline-fallback.ts). The only scripted bit is
- * OfflineActions' reload, which the snapshot rewires via `data-offline-reload`.
+ * backdrop + display type) with an amber accent. It reacts to the network
+ * returning via OFFLINE_RECONNECT_SCRIPT (rendered inline below): the accent
+ * transitions amber -> emerald, the copy updates, and an optional 5s auto-reload
+ * kicks in. The script is dependency-free and drives the DOM through data
+ * attributes, so it runs identically here and in the script-stripped fallback
+ * snapshot (see scripts/generate-offline-fallback.ts). The initial render is the
+ * offline state; the script swaps to the online state after hydration.
  */
 export default function OfflineStage() {
     return (
         <main
+            data-offline-root
+            data-status="offline"
+            // The reconnect script may flip data-status (and the text below) to the
+            // online state before React hydrates when the device is already online,
+            // so suppress the hydration diff on the nodes it mutates, mirroring the
+            // pre-paint theme script on <html> in the root layout. Without JS the
+            // SSR offline state stands.
+            suppressHydrationWarning
             className={cn(
                 styles.stage,
                 zain.variable,
@@ -28,22 +46,54 @@ export default function OfflineStage() {
             <span className="border-foreground/10 bg-background/60 text-foreground/70 mt-8 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium backdrop-blur-sm">
                 <span
                     aria-hidden="true"
-                    className="size-2 rounded-full bg-amber-500 motion-safe:animate-pulse"
+                    className={cn(styles.dot, 'size-2 rounded-full')}
                 />
-                No connection
+                <span
+                    data-offline-status
+                    suppressHydrationWarning
+                >
+                    {OFFLINE_STATUS}
+                </span>
             </span>
 
-            <h1 className="font-display mt-6 text-[length:clamp(3.5rem,17vw,9rem)] leading-[0.82] font-bold tracking-tight">
-                Offline
+            <h1
+                data-offline-title
+                suppressHydrationWarning
+                className="font-display mt-6 text-[length:clamp(3.5rem,17vw,9rem)] leading-[0.82] font-bold tracking-tight"
+            >
+                {OFFLINE_HEADING}
             </h1>
 
-            <p className="text-foreground/70 mt-6 max-w-xl text-lg leading-relaxed text-balance">
-                You have slipped off the grid. This page was not saved for
-                offline reading, so reconnect to load it, or head back to
-                somewhere you have already been.
+            <p
+                data-offline-copy
+                suppressHydrationWarning
+                className="text-foreground/70 mt-6 max-w-xl text-lg leading-relaxed text-balance"
+            >
+                {OFFLINE_COPY}
             </p>
 
             <OfflineActions />
+
+            <label
+                className={cn(
+                    styles.autoReload,
+                    'text-foreground/60 hover:text-foreground/80 mt-6 cursor-pointer items-center gap-2 text-sm transition-colors'
+                )}
+            >
+                <input
+                    type="checkbox"
+                    data-offline-autoreload
+                    className={cn(styles.checkbox, 'size-4 rounded')}
+                />
+                {AUTO_RELOAD_LABEL}
+                <span
+                    data-offline-countdown
+                    className="text-foreground/80 font-medium tabular-nums"
+                />
+            </label>
+
+            {/* Reconnect behaviour, shared verbatim with the fallback snapshot. */}
+            <script dangerouslySetInnerHTML={{ __html: OFFLINE_RECONNECT_SCRIPT }} />
         </main>
     );
 }

--- a/src/components/pages/offline/SignalRings/SignalRings.module.css
+++ b/src/components/pages/offline/SignalRings/SignalRings.module.css
@@ -1,24 +1,24 @@
 @reference "tailwindcss";
 
 /* Radar "searching for signal" glyph. Everything expressible as a utility uses
-   @apply; the amber tint (color-mix) and the pulse keyframes are the sanctioned
-   raw-CSS exceptions. The rings and core share the amber signal colour that also
-   drives the "No connection" status dot, keeping the offline accent consistent. */
+   @apply; the accent tint (color-mix) and the pulse keyframes are the sanctioned
+   raw-CSS exceptions. The rings and core inherit --offline-accent from the stage
+   (OfflineStage.module.css) so they share, and transition with, the status
+   accent: amber while offline, emerald once the connection returns. */
 .radar {
     @apply size-28 sm:size-32;
-    --signal: var(--color-amber-500);
 }
 
 /* A persistent faint target ring so the glyph reads even at rest (a still frame
    or reduced motion), under the outward pulses. */
 .halo {
     @apply absolute size-2/3 rounded-full border opacity-30 content-[''];
-    border-color: color-mix(in oklab, var(--signal) 55%, transparent);
+    border-color: color-mix(in oklab, var(--offline-accent) 55%, transparent);
 }
 
 .ring {
     @apply absolute size-full rounded-full border content-[''];
-    border-color: color-mix(in oklab, var(--signal) 45%, transparent);
+    border-color: color-mix(in oklab, var(--offline-accent) 45%, transparent);
     /* Reduced-motion / no-animation resting state: one faint static ring. */
     @apply opacity-40;
     /* With motion allowed, the rings start collapsed and transparent and the
@@ -36,8 +36,9 @@
 
 .core {
     @apply absolute size-3 rounded-full;
-    background-color: var(--signal);
-    box-shadow: 0 0 0 6px color-mix(in oklab, var(--signal) 22%, transparent);
+    background-color: var(--offline-accent);
+    box-shadow: 0 0 0 6px
+        color-mix(in oklab, var(--offline-accent) 22%, transparent);
 }
 
 @keyframes radar-pulse {

--- a/src/components/pages/offline/offlineReconnect.ts
+++ b/src/components/pages/offline/offlineReconnect.ts
@@ -1,0 +1,58 @@
+// Shared source of truth for the offline page's reconnect behaviour, used by
+// both the hydrated /offline route (OfflineStage renders the script inline) and
+// the script-stripped offline fallback snapshot (scripts/generate-offline-fallback.ts
+// re-injects it). Keeping it framework-agnostic means one implementation covers
+// both runtimes: the fallback is the surface actually shown while offline, so the
+// behaviour has to work without React.
+
+export const OFFLINE_AUTO_RELOAD_KEY = 'offline-auto-reload';
+export const OFFLINE_RELOAD_DELAY_SECONDS = 5;
+
+// Copy for each state. The offline strings are the initial (server-rendered)
+// content; the script swaps to the online strings when the connection returns.
+export const OFFLINE_HEADING = 'Offline';
+export const ONLINE_HEADING = 'Online';
+export const OFFLINE_STATUS = 'No connection';
+export const ONLINE_STATUS = 'Back online';
+export const OFFLINE_COPY =
+    'You have slipped off the grid. This page was not saved for offline reading, so reconnect to load it, or head back to somewhere you have already been.';
+export const ONLINE_COPY =
+    'You are back online. Reload to pick up where you left off.';
+export const AUTO_RELOAD_LABEL = 'Automatically reload when the connection returns';
+
+/**
+ * A dependency-free IIFE that makes the offline page react to the network coming
+ * back: it flips `data-status` on the root (which the CSS transitions from the
+ * amber offline accent to the emerald online accent), swaps the heading/status/
+ * copy text, and, when the auto-reload preference is on, counts down and reloads
+ * so the page the user actually wanted resolves. The preference is persisted, and
+ * the visible countdown plus checkbox give a window to opt out. Auto-reload is
+ * skipped on the /offline route itself (reloading it is pointless and would loop);
+ * it only runs when this page is serving as the navigation fallback at another URL.
+ */
+export const OFFLINE_RECONNECT_SCRIPT = `(function(){
+  var root=document.querySelector('[data-offline-root]');
+  if(!root)return;
+  var KEY=${JSON.stringify(OFFLINE_AUTO_RELOAD_KEY)};
+  var DELAY=${OFFLINE_RELOAD_DELAY_SECONDS};
+  var title=root.querySelector('[data-offline-title]');
+  var copy=root.querySelector('[data-offline-copy]');
+  var status=root.querySelector('[data-offline-status]');
+  var box=root.querySelector('[data-offline-autoreload]');
+  var countdown=root.querySelector('[data-offline-countdown]');
+  var isFallback=location.pathname!=='/offline';
+  var timer=null;
+  function getPref(){try{var v=localStorage.getItem(KEY);return v===null?true:v==='1';}catch(e){return true;}}
+  function setPref(v){try{localStorage.setItem(KEY,v?'1':'0');}catch(e){}}
+  function stop(){if(timer){clearInterval(timer);timer=null;}if(countdown)countdown.textContent='';}
+  function start(){if(!isFallback)return;stop();var s=DELAY;render();timer=setInterval(function(){s--;if(s<=0){stop();location.reload();return;}render();},1000);function render(){if(countdown)countdown.textContent='Reloading in '+s+'s\\u2026';}}
+  function online(){root.setAttribute('data-status','online');if(title)title.textContent=${JSON.stringify(ONLINE_HEADING)};if(status)status.textContent=${JSON.stringify(ONLINE_STATUS)};if(copy)copy.textContent=${JSON.stringify(ONLINE_COPY)};if(box&&box.checked)start();}
+  function offline(){stop();root.setAttribute('data-status','offline');if(title)title.textContent=${JSON.stringify(OFFLINE_HEADING)};if(status)status.textContent=${JSON.stringify(OFFLINE_STATUS)};if(copy)copy.textContent=${JSON.stringify(OFFLINE_COPY)};}
+  if(box){box.checked=getPref();box.addEventListener('change',function(){setPref(box.checked);if(!box.checked)stop();else if(navigator.onLine&&root.getAttribute('data-status')==='online')start();});}
+  window.addEventListener('online',online);
+  window.addEventListener('offline',offline);
+  root.addEventListener('click',function(e){if(e.target.closest('[data-offline-reload]')){e.preventDefault();location.reload();}});
+  // Deferred so React (on the /offline route) hydrates the default offline markup
+  // first; mutating after hydration avoids a mismatch.
+  setTimeout(function(){if(navigator.onLine)online();},0);
+})();`;


### PR DESCRIPTION
When the network comes back, the offline page now flips from its amber "lost signal" state to an emerald "back online" state: the accent transitions amber -> emerald, the heading/status/copy update, and an opt-out auto-reload kicks in.

- offlineReconnect.ts: a dependency-free script (plus shared copy) that listens for online/offline, drives the DOM via data attributes, and, when the persisted auto-reload preference is on, counts down 5s and reloads the URL the user actually wanted. The visible countdown and checkbox give a window to opt out; auto-reload is skipped on /offline itself to avoid a reload loop. One implementation covers both runtimes: OfflineStage renders it inline for the route, and the snapshot generator injects the same source, so it works in the script-stripped fallback (the surface actually shown while offline).
- OfflineStage: data attributes, the auto-reload checkbox + countdown, and suppressHydrationWarning on the nodes the script may mutate before hydration (mirrors the pre-paint theme script on <html>).
- Accent rides a registered @property --offline-accent so the amber -> emerald swap animates across the radar rings, status dot, and bloom; SignalRings inherits it.
- OfflineActions is now a server component; its reload is handled by the shared script's delegated data-offline-reload listener.

Verified with headless Chromium + CDP: dispatching online/offline swaps the rendered accent (emerald oklch h162 <-> amber) and the copy, the checkbox defaults on and persists on uncheck, the countdown runs and cancels, and /offline hydrates with no mismatch.