### PR TITLE
refactor(ui): build the offline page from shared UI primitives

### DIFF
--- a/src/components/pages/offline/OfflineActions.tsx
+++ b/src/components/pages/offline/OfflineActions.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
 import Button from '@/components/ui/Button';
+import ButtonLink from '@/components/ui/ButtonLink';
 import ResetIcon from '@/components/icons/reset';
 
 /**
@@ -22,12 +22,12 @@ export default function OfflineActions() {
                 />
                 Try again
             </Button>
-            <Link
+            <ButtonLink
                 href="/"
-                className="border-foreground/15 hover:bg-foreground/5 inline-flex items-center justify-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-semibold transition-colors"
+                variant="outline"
             >
                 Back home
-            </Link>
+            </ButtonLink>
         </div>
     );
 }

--- a/src/components/pages/offline/OfflineStage/OfflineStage.module.css
+++ b/src/components/pages/offline/OfflineStage/OfflineStage.module.css
@@ -77,7 +77,3 @@
 .stage[data-status='online'] .autoReload {
     @apply flex;
 }
-
-.checkbox {
-    accent-color: var(--offline-accent);
-}

--- a/src/components/pages/offline/OfflineStage/index.tsx
+++ b/src/components/pages/offline/OfflineStage/index.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/utils/cn';
 import GridBackground from '@/components/backgrounds/GridBackground';
+import Checkbox from '@/components/ui/Checkbox';
 import SignalRings from '@/components/pages/offline/SignalRings';
 import OfflineActions from '@/components/pages/offline/OfflineActions';
 import {
@@ -74,23 +75,18 @@ export default function OfflineStage() {
 
             <OfflineActions />
 
-            <label
-                className={cn(
-                    styles.autoReload,
-                    'text-foreground/60 hover:text-foreground/80 mt-6 cursor-pointer items-center gap-2 text-sm transition-colors'
-                )}
-            >
-                <input
-                    type="checkbox"
+            <div className={cn(styles.autoReload, 'mt-6 items-center gap-2')}>
+                <Checkbox
+                    label={AUTO_RELOAD_LABEL}
                     data-offline-autoreload
-                    className={cn(styles.checkbox, 'size-4 rounded')}
+                    className="accent-[var(--offline-accent)]"
+                    labelClassName="text-foreground/60 hover:text-foreground/80 transition-colors"
                 />
-                {AUTO_RELOAD_LABEL}
                 <span
                     data-offline-countdown
                     className="text-foreground/80 font-medium tabular-nums"
                 />
-            </label>
+            </div>
 
             {/* Reconnect behaviour, shared verbatim with the fallback snapshot. */}
             <script dangerouslySetInnerHTML={{ __html: OFFLINE_RECONNECT_SCRIPT }} />

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -1,7 +1,10 @@
 import { cn } from '@/utils/cn';
 import Spinner from '@/components/ui/Spinner';
 
-type ButtonVariant = 'primary' | 'outline';
+export type ButtonVariant = 'primary' | 'outline';
+
+const buttonBaseClassName =
+    'inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors';
 
 const variantClassNames: Record<ButtonVariant, string> = {
     primary:
@@ -9,6 +12,18 @@ const variantClassNames: Record<ButtonVariant, string> = {
     outline:
         'border-foreground/15 border hover:bg-foreground/5 disabled:cursor-not-allowed disabled:opacity-60',
 };
+
+/**
+ * The shared button styling, reused by Button and by ButtonLink (a link that
+ * reads as a button). Kept separate so a non-`<button>` element can wear the same
+ * look without duplicating the class list.
+ */
+export function buttonClassName(
+    variant: ButtonVariant = 'primary',
+    className?: string
+): string {
+    return cn(buttonBaseClassName, variantClassNames[variant], className);
+}
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
     variant?: ButtonVariant;
@@ -33,11 +48,7 @@ export default function Button({
         <button
             type={type}
             disabled={disabled || isLoading}
-            className={cn(
-                'inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors',
-                variantClassNames[variant],
-                className
-            )}
+            className={buttonClassName(variant, className)}
             {...rest}
         >
             {isLoading && <Spinner />}

--- a/src/components/ui/ButtonLink/index.tsx
+++ b/src/components/ui/ButtonLink/index.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import type { ComponentProps } from 'react';
+import { buttonClassName, type ButtonVariant } from '@/components/ui/Button';
+
+type ButtonLinkProps = ComponentProps<typeof Link> & {
+    variant?: ButtonVariant;
+};
+
+/**
+ * A link that reads as a button, sharing Button's variants and styling. Use for
+ * navigations that should look like button actions (e.g. an offline page's "Back
+ * home"), keeping the look in one place instead of re-styling an anchor.
+ */
+export default function ButtonLink({
+    variant = 'primary',
+    className,
+    ...rest
+}: ButtonLinkProps) {
+    return (
+        <Link
+            className={buttonClassName(variant, className)}
+            {...rest}
+        />
+    );
+}

--- a/src/components/ui/Checkbox/index.tsx
+++ b/src/components/ui/Checkbox/index.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/utils/cn';
+
+type CheckboxProps = React.ComponentPropsWithRef<'input'> & {
+    label: string;
+    labelClassName?: string;
+};
+
+/**
+ * Labeled checkbox on the `foreground` accent token. The label wraps the input so
+ * the whole row is clickable; `data-*` and every other input prop is forwarded.
+ * Pass an `accent-[...]` utility via `className` to override the accent colour.
+ */
+export default function Checkbox({
+    label,
+    labelClassName,
+    className,
+    ...rest
+}: CheckboxProps) {
+    return (
+        <label
+            className={cn(
+                'inline-flex cursor-pointer items-center gap-2 text-sm',
+                labelClassName
+            )}
+        >
+            <input
+                type="checkbox"
+                className={cn('accent-foreground size-4 rounded', className)}
+                {...rest}
+            />
+            {label}
+        </label>
+    );
+}


### PR DESCRIPTION
Reuse the shared UI components instead of hand-rolling markup, and add the missing primitives so future pages can reuse them too.

- Button: extract and export buttonClassName(variant, className) and ButtonVariant so the button look lives in one place.
- ButtonLink: new shared component, a next/link styled as a button via buttonClassName, for navigations that read as button actions.
- Checkbox: new shared labeled checkbox on the foreground accent token that forwards data-*/all input props; the accent is overridable with an accent-[...] utility.
- Offline page: "Back home" now uses ButtonLink (was an anchor with a copied outline class list), and the auto-reload control uses Checkbox (was a raw input); drop the dead .checkbox module rule.