### PR TITLE
fix(network-status): confirm reachability before showing online

### DIFF
--- a/src/components/pages/network-status/reconnect.ts
+++ b/src/components/pages/network-status/reconnect.ts
@@ -45,17 +45,24 @@ export const RECONNECT_SCRIPT = `(function(){
   var countdown=root.querySelector('[data-network-countdown]');
   var isFallback=location.pathname!=='/network-status';
   var timer=null;
+  var probing=false;
   function getPref(){try{var v=localStorage.getItem(KEY);return v===null?true:v==='1';}catch(e){return true;}}
   function setPref(v){try{localStorage.setItem(KEY,v?'1':'0');}catch(e){}}
   function stop(){if(timer){clearInterval(timer);timer=null;}if(countdown)countdown.textContent='';}
   function start(){if(!isFallback)return;stop();var s=DELAY;render();timer=setInterval(function(){s--;if(s<=0){stop();location.reload();return;}render();},1000);function render(){if(countdown)countdown.textContent='Reloading in '+s+'s\\u2026';}}
   function online(){root.setAttribute('data-status','online');if(title)title.textContent=${JSON.stringify(ONLINE_HEADING)};if(status)status.textContent=${JSON.stringify(ONLINE_STATUS)};if(copy)copy.textContent=${JSON.stringify(ONLINE_COPY)};if(box&&box.checked)start();}
   function offline(){stop();root.setAttribute('data-status','offline');if(title)title.textContent=${JSON.stringify(OFFLINE_HEADING)};if(status)status.textContent=${JSON.stringify(OFFLINE_STATUS)};if(copy)copy.textContent=${JSON.stringify(OFFLINE_COPY)};}
+  // navigator.onLine===true only means a network interface exists, not that the
+  // server is reachable (e.g. DevTools throttling-offline leaves it true), so
+  // confirm with a real network fetch before declaring online. version.json is
+  // small, same-origin, and network-only (cache-busted + no-store fall through
+  // the SW), so it genuinely fails when offline.
+  function confirmOnline(){if(navigator.onLine===false){offline();return;}if(probing)return;probing=true;fetch('/version.json?probe='+Date.now(),{cache:'no-store'}).then(function(r){probing=false;if(r&&r.ok)online();else offline();}).catch(function(){probing=false;offline();});}
   if(box){box.checked=getPref();box.addEventListener('change',function(){setPref(box.checked);if(!box.checked)stop();else if(navigator.onLine&&root.getAttribute('data-status')==='online')start();});}
-  window.addEventListener('online',online);
+  window.addEventListener('online',confirmOnline);
   window.addEventListener('offline',offline);
   root.addEventListener('click',function(e){if(e.target.closest('[data-network-reload]')){e.preventDefault();location.reload();}});
   // Deferred so React (on the /network-status route) hydrates the default offline
   // markup first; mutating after hydration avoids a mismatch.
-  setTimeout(function(){if(navigator.onLine)online();},0);
+  setTimeout(confirmOnline,0);
 })();`;


### PR DESCRIPTION
navigator.onLine===true only means a network interface exists, not that the server is reachable, so DevTools throttling-offline (which does not flip navigator.onLine) left the page reading Online while real mobile radio-off worked. Gate the online transition behind a network-only fetch probe (version.json, cache-busted + no-store) that genuinely fails when offline; treat navigator.onLine===false as offline without probing. Runs in both the /network-status route and the offline-fallback snapshot, which share this script verbatim.