### PR TITLE
feat(navbar): sync theme switcher reveal and speed up idle reveal

### DIFF
--- a/src/components/layout/Navbar/hooks/useNavbarVisibility.ts
+++ b/src/components/layout/Navbar/hooks/useNavbarVisibility.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 // How long a visitor must linger at the very top of the home page, without
 // scrolling, before the navbar reveals itself on its own.
-const IDLE_REVEAL_DELAY_MS = 2000;
+const IDLE_REVEAL_DELAY_MS = 1000;
 
 /**
  * Whether the navbar should be shown. On the home page it stays hidden until

--- a/src/components/layout/Navbar/index.tsx
+++ b/src/components/layout/Navbar/index.tsx
@@ -62,7 +62,7 @@ export default function Navbar({
                 studioItems={studio}
                 isActive={isActive}
             />
-            <ThemeMenu />
+            <ThemeMenu visible={visible} />
         </>
     );
 }

--- a/src/components/layout/ThemeToggle/ThemeMenu.tsx
+++ b/src/components/layout/ThemeToggle/ThemeMenu.tsx
@@ -13,9 +13,10 @@ import { useCloseOnRouteChange } from '@/components/layout/Navbar/hooks/useClose
  * Desktop theme control: a round icon button fixed to the top-right that opens a
  * small menu of the three preferences (light / system / dark). The trigger shows
  * the current preference's icon. Hidden on mobile, where the segmented
- * ThemeToggle lives inside the menu panel instead.
+ * ThemeToggle lives inside the menu panel instead. It shares the navbar's
+ * `visible` state, sliding in from the right edge in sync with it.
  */
-export default function ThemeMenu() {
+export default function ThemeMenu({ visible }: { visible: boolean }) {
     const { preference, setPreference } = useTheme();
     const { open, toggle, close } = useDisclosure();
     const menuRef = useRef<HTMLDivElement>(null);
@@ -30,7 +31,12 @@ export default function ThemeMenu() {
     return (
         <div
             ref={menuRef}
-            className="fixed top-4 right-4 z-50 hidden md:block"
+            className={cn(
+                'fixed top-4 right-4 z-50 hidden transition-all duration-700 ease-in-out motion-reduce:transition-none md:block',
+                visible
+                    ? 'visible translate-x-0 opacity-100'
+                    : 'pointer-events-none invisible translate-x-24 opacity-0'
+            )}
         >
             <button
                 type="button"


### PR DESCRIPTION
Slide the desktop theme switcher in from the right edge in sync with the navbar's visible state instead of always showing it, and shorten the home page idle-reveal delay from 2s to 1s.