### PR TITLE
fix(ui): tighten accessibility, motion, and design-system consistency

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -17,13 +17,13 @@ export default function Error({ reset }: { error: Error; reset: () => void }) {
                 <button
                     type="button"
                     onClick={reset}
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-all duration-300 hover:scale-105"
+                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
                 >
                     Try again
                 </button>
                 <Link
                     href="/"
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-all duration-300 hover:scale-105"
+                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
                 >
                     Back home
                 </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,6 +202,25 @@ body {
     }
 }
 
+/* Global reduced-motion safety net. The site opts into motion per component
+   (motion-safe utilities and prefers-reduced-motion: no-preference blocks), but
+   any inline transition or animate utility that misses the gate would still run
+   at full motion. This blanket reset neutralises animation, transition, and
+   smooth scroll for users who ask for reduced motion, so the per-component
+   gating can never be silently undermined. Kept minimal (duration collapse,
+   single iteration) so state changes still apply instantly rather than snapping
+   mid-transition. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
 /* Smooth gradient background for homepage content sections (issue #13).
    Each direct section of the homepage main swells from the base background
    to a faint wash of its own accent and back, so consecutive sections share

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -22,13 +22,13 @@ export default function NotFound() {
             <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
                 <Link
                     href="/"
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-all duration-300 hover:scale-105"
+                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
                 >
                     Back home
                 </Link>
                 <Link
                     href="/articles"
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-all duration-300 hover:scale-105"
+                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
                 >
                     Read articles
                 </Link>

--- a/src/components/layout/Navbar/DesktopNav.tsx
+++ b/src/components/layout/Navbar/DesktopNav.tsx
@@ -27,7 +27,7 @@ export default function DesktopNav({
         <nav
             aria-label="Primary"
             className={cn(
-                'fixed top-4 left-1/2 z-50 hidden -translate-x-1/2 transition-all duration-700 ease-in-out motion-reduce:transition-none md:block',
+                'fixed top-4 left-1/2 z-50 hidden -translate-x-1/2 transition-[transform,opacity] duration-700 ease-in-out motion-reduce:transition-none md:block',
                 visible
                     ? 'visible translate-y-0 opacity-100'
                     : 'pointer-events-none invisible -translate-y-24 opacity-0'

--- a/src/components/layout/Navbar/MobileMenuPanel.tsx
+++ b/src/components/layout/Navbar/MobileMenuPanel.tsx
@@ -91,7 +91,7 @@ export default function MobileMenuPanel({
                         aria-hidden="true"
                         className="bg-foreground/10 my-1 h-px"
                     />
-                    <p className="text-foreground/40 px-4 pt-1 pb-0.5 text-xs font-semibold tracking-wide uppercase">
+                    <p className="text-foreground/60 px-4 pt-1 pb-0.5 text-xs font-semibold tracking-wide uppercase">
                         Studio
                     </p>
                     <ul className="flex flex-col gap-0.5">

--- a/src/components/pages/articles/ArticleCard/ArticleCard.module.css
+++ b/src/components/pages/articles/ArticleCard/ArticleCard.module.css
@@ -1,12 +1,18 @@
 @reference "tailwindcss";
 
-/* Soft, top-to-bottom glow revealed on article-card hover (#articles / #work),
-   coloured to match the card's cover thumbnail. A ::before layer behind the card
-   content (the card is `relative isolate`, so z-index keeps it under the image and
-   text) holds a vertical gradient built from the cover's two colours (--cover-from
-   / --cover-to, set inline per card) fading out downward. It glows in slowly on
-   hover via a long opacity transition. Deliberately very soft, and softer still in
-   dark mode. @apply covers the utility-mappable rules; the gradient is raw CSS. */
+/* Soft accent bloom revealed on article-card hover (#articles / #work), coloured
+   to match the card's cover thumbnail. A ::before layer behind the card content
+   (the card is `relative isolate`, so z-index keeps it under the image and text)
+   holds the signature radial bloom (matching SkillCard/ProjectCard/NowCard/
+   UsesCard) built from the cover's two colours (--cover-from / --cover-to, set
+   inline per card). Both washes are wide, shallow ellipses whose hotspots sit
+   right at the cover thumbnail's bottom edge (the image fills roughly the top 45%
+   of the card): the upper half of each ellipse is hidden behind the opaque image,
+   so what shows is the accent spilling out from under the thumbnail and fading
+   downward, cover-from into cover-to, as if the image itself is glowing. It glows
+   in slowly on hover via a long opacity transition. Deliberately very soft, and
+   softer still in dark mode. @apply covers the utility-mappable rules; the
+   radial-gradient + color-mix are the sanctioned raw-CSS exceptions. */
 .card {
     --tint-strength: 8%;
 }
@@ -25,22 +31,25 @@
 
 .card::before {
     @apply pointer-events-none absolute inset-0 z-[-1] opacity-0 content-[''] motion-safe:transition-opacity motion-safe:duration-700;
-    background-image: linear-gradient(
-        to bottom,
-        color-mix(
+    background-image:
+        radial-gradient(
+            120% 50% at 50% 43%,
+            color-mix(
                 in oklab,
                 var(--cover-from, var(--foreground)) var(--tint-strength),
                 transparent
-            )
-            0%,
-        color-mix(
+            ),
+            transparent 70%
+        ),
+        radial-gradient(
+            95% 45% at 50% 58%,
+            color-mix(
                 in oklab,
-                var(--cover-to, var(--foreground)) var(--tint-strength),
+                var(--cover-to, var(--foreground)) calc(var(--tint-strength) * 0.5),
                 transparent
-            )
-            50%,
-        transparent 92%
-    );
+            ),
+            transparent 74%
+        );
 }
 
 .card:hover::before {

--- a/src/components/pages/articles/ArticleContent/ArticleContent.module.css
+++ b/src/components/pages/articles/ArticleContent/ArticleContent.module.css
@@ -7,12 +7,22 @@
 /* Inline code: Slack-style chip (crimson text on a subtle gray, bordered,
    rounded pill), JetBrains Mono, without Typography's backtick quotes. The
    background/border mix var(--foreground), so they adapt to light/dark on
-   their own; Slack keeps the crimson text color in both themes. */
+   their own. The crimson is theme-aware: a deeper rose in light and a lighter
+   rose in dark, so the small chip text clears WCAG AA (4.5:1) against the chip
+   background in both themes (a single crimson landed near 3:1 in dark). */
 .content :where(code):not(:where(pre *)) {
-    @apply rounded border px-[0.35em] py-[0.15em] text-[0.85em] font-medium text-[#e01e5a];
+    @apply rounded border px-[0.35em] py-[0.15em] text-[0.85em] font-medium text-[#be123c];
     font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
     background-color: color-mix(in srgb, var(--foreground) 4%, transparent);
     border-color: color-mix(in srgb, var(--foreground) 13%, transparent);
+}
+@media (prefers-color-scheme: dark) {
+    :global(html:not([data-theme])) .content :where(code):not(:where(pre *)) {
+        @apply text-[#fb7185];
+    }
+}
+:global(html[data-theme='dark']) .content :where(code):not(:where(pre *)) {
+    @apply text-[#fb7185];
 }
 .content :where(code):not(:where(pre *))::before,
 .content :where(code):not(:where(pre *))::after {

--- a/src/components/pages/articles/ArticlePager.tsx
+++ b/src/components/pages/articles/ArticlePager.tsx
@@ -23,7 +23,7 @@ function PagerLink({ article, direction, alignEnd = false }: PagerLinkProps) {
                 alignEnd ? 'sm:col-start-2 sm:items-end sm:text-right' : ''
             )}
         >
-            <span className="text-foreground/50 flex items-center gap-1.5 text-xs font-semibold tracking-[0.08em] uppercase">
+            <span className="text-foreground/70 flex items-center gap-1.5 text-xs font-semibold tracking-[0.08em] uppercase">
                 {!isNext && (
                     <ChevronIcon className="size-3.5 -rotate-90 transition-transform group-hover:-translate-x-0.5" />
                 )}

--- a/src/components/pages/articles/ArticleSearch/SearchModal.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchModal.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/utils/cn';
 import type { ArticleSummary } from '@/lib/posts';
 
 const kbd =
-    'border-foreground/20 text-foreground/50 inline-flex h-4 min-w-4 items-center justify-center rounded border px-1 text-[0.65rem]';
+    'border-foreground/20 text-foreground/70 inline-flex h-4 min-w-4 items-center justify-center rounded border px-1 text-[0.65rem]';
 
 /**
  * Command-palette style search over the pre-generated articles, shown above a
@@ -76,7 +76,7 @@ export default function SearchModal({
                 <div className="border-foreground/10 flex items-center gap-3 border-b px-4 py-3.5">
                     <Search
                         aria-hidden="true"
-                        className="text-foreground/40 size-5 shrink-0"
+                        className="text-foreground/55 size-5 shrink-0"
                     />
                     <input
                         ref={inputRef}
@@ -91,19 +91,19 @@ export default function SearchModal({
                         onChange={box.onChange}
                         onKeyDown={box.onKeyDown}
                         placeholder="Search articles by title or tag..."
-                        className="placeholder:text-foreground/40 w-full bg-transparent text-base outline-none [&::-webkit-search-cancel-button]:appearance-none"
+                        className="placeholder:text-foreground/55 w-full bg-transparent text-base outline-none [&::-webkit-search-cancel-button]:appearance-none"
                     />
                     {box.query.length > 0 ? (
                         <button
                             type="button"
                             onClick={box.clear}
                             aria-label="Clear search"
-                            className="text-foreground/40 hover:text-foreground hover:bg-foreground/10 grid size-7 shrink-0 place-items-center rounded-full transition-colors"
+                            className="text-foreground/55 hover:text-foreground hover:bg-foreground/10 grid size-7 shrink-0 place-items-center rounded-full transition-colors"
                         >
                             <Close className="size-4" />
                         </button>
                     ) : (
-                        <kbd className="border-foreground/20 text-foreground/50 hidden shrink-0 rounded border px-1.5 py-0.5 text-[0.65rem] sm:inline-block">
+                        <kbd className="border-foreground/20 text-foreground/70 hidden shrink-0 rounded border px-1.5 py-0.5 text-[0.65rem] sm:inline-block">
                             Esc
                         </kbd>
                     )}
@@ -124,7 +124,7 @@ export default function SearchModal({
                             onSelectArticle={box.goToArticle}
                             onSearchAll={box.goToResults}
                         />
-                        <div className="border-foreground/10 text-foreground/50 flex items-center justify-between gap-3 border-t px-4 py-2.5 text-xs">
+                        <div className="border-foreground/10 text-foreground/70 flex items-center justify-between gap-3 border-t px-4 py-2.5 text-xs">
                             <span>
                                 <span className="text-foreground font-medium">
                                     {box.resultCount}
@@ -145,7 +145,7 @@ export default function SearchModal({
                         </div>
                     </>
                 ) : (
-                    <p className="text-foreground/50 px-4 py-6 text-sm">
+                    <p className="text-foreground/70 px-4 py-6 text-sm">
                         Start typing to find an article by its title or a tag.
                     </p>
                 )}

--- a/src/components/pages/articles/ArticleSearch/SearchSuggestionItem.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchSuggestionItem.tsx
@@ -51,13 +51,13 @@ export default function SearchSuggestionItem({
                     />
                 </span>
                 <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="text-foreground/45 text-xs">
+                    <span className="text-foreground/60 text-xs">
                         {formatDate(article.date)}
                     </span>
                     {article.tags.map((tag) => (
                         <span
                             key={tag}
-                            className="bg-foreground/[0.06] text-foreground/55 rounded-full px-2 py-0.5 text-[0.7rem]"
+                            className="bg-foreground/[0.06] text-foreground/70 rounded-full px-2 py-0.5 text-[0.7rem]"
                         >
                             <HighlightedText
                                 text={tag}

--- a/src/components/pages/articles/ArticleSearch/SearchSuggestions.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchSuggestions.tsx
@@ -87,7 +87,7 @@ export default function SearchSuggestions({
                 >
                     <Search
                         aria-hidden="true"
-                        className="text-foreground/50 size-4 shrink-0"
+                        className="text-foreground/70 size-4 shrink-0"
                     />
                     <span className="text-foreground/70 min-w-0 truncate">
                         Search for{' '}
@@ -95,7 +95,7 @@ export default function SearchSuggestions({
                             “{trimmed}”
                         </span>
                     </span>
-                    <kbd className="border-foreground/20 text-foreground/50 ml-auto hidden shrink-0 rounded border px-1.5 py-0.5 text-[0.65rem] sm:inline-block">
+                    <kbd className="border-foreground/20 text-foreground/70 ml-auto hidden shrink-0 rounded border px-1.5 py-0.5 text-[0.65rem] sm:inline-block">
                         Enter
                     </kbd>
                 </button>

--- a/src/components/pages/articles/ArticleSearch/SearchTrigger.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchTrigger.tsx
@@ -6,7 +6,7 @@ import { useIsMac } from '@/components/pages/articles/ArticleSearch/hooks/useIsM
 import { cn } from '@/utils/cn';
 
 const keycap =
-    'border-foreground/15 bg-foreground/[0.04] text-foreground/55 group-hover:border-foreground/30 group-hover:text-foreground/80 inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-b-2 px-1 font-mono text-[0.7rem] leading-none transition-colors';
+    'border-foreground/15 bg-foreground/[0.04] text-foreground/70 group-hover:border-foreground/30 group-hover:text-foreground/80 inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-b-2 px-1 font-mono text-[0.7rem] leading-none transition-colors';
 
 /**
  * The search affordance on the articles pages: a button that opens the search
@@ -33,7 +33,7 @@ export default function SearchTrigger({
             title="Search articles"
             className={cn(
                 jetBrainsMono.variable,
-                'group border-foreground/15 text-foreground/55 hover:border-foreground/40 hover:text-foreground hover:bg-foreground/[0.04] inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-xl border transition-colors sm:w-auto sm:justify-start sm:gap-2.5 sm:pr-2.5 sm:pl-3',
+                'group border-foreground/15 text-foreground/70 hover:border-foreground/40 hover:text-foreground hover:bg-foreground/[0.04] inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-xl border transition-colors sm:w-auto sm:justify-start sm:gap-2.5 sm:pr-2.5 sm:pl-3',
                 className
             )}
         >

--- a/src/components/pages/articles/CodeBlock/CodeCopyButton.tsx
+++ b/src/components/pages/articles/CodeBlock/CodeCopyButton.tsx
@@ -12,7 +12,7 @@ export default function CodeCopyButton({ code }: { code: string }) {
             type="button"
             aria-label={copied ? 'Copied' : 'Copy code'}
             onClick={() => copy(code)}
-            className="text-foreground/55 hover:bg-foreground/10 hover:text-foreground focus-visible:bg-foreground/10 focus-visible:text-foreground inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors"
+            className="text-foreground/70 hover:bg-foreground/10 hover:text-foreground focus-visible:bg-foreground/10 focus-visible:text-foreground inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors"
         >
             {copied ? (
                 <>

--- a/src/components/pages/articles/MermaidRenderer/MermaidDiagram.tsx
+++ b/src/components/pages/articles/MermaidRenderer/MermaidDiagram.tsx
@@ -19,7 +19,7 @@ export default function MermaidDiagram({ source }: { source: string }) {
 
     if (!svg) {
         return (
-            <pre className="not-prose border-foreground/10 text-foreground/55 overflow-x-auto rounded-xl border p-4 text-sm">
+            <pre className="not-prose border-foreground/10 text-foreground/70 overflow-x-auto rounded-xl border p-4 text-sm">
                 {source}
             </pre>
         );

--- a/src/components/pages/articles/Pagination.tsx
+++ b/src/components/pages/articles/Pagination.tsx
@@ -61,7 +61,7 @@ export default function Pagination({
                         aria-hidden="true"
                         className={cn(
                             itemBase,
-                            'text-foreground/40 border-transparent'
+                            'text-foreground/55 border-transparent'
                         )}
                     >
                         …

--- a/src/components/pages/articles/SeriesNav.tsx
+++ b/src/components/pages/articles/SeriesNav.tsx
@@ -35,10 +35,10 @@ export default function SeriesNav({
             )}
         >
             <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                <p className="text-foreground/45 text-xs font-semibold tracking-[0.12em] uppercase">
+                <p className="text-foreground/60 text-xs font-semibold tracking-[0.12em] uppercase">
                     Part {position} of {series.parts.length}
                 </p>
-                <p className="text-foreground/55 text-xs">Series</p>
+                <p className="text-foreground/70 text-xs">Series</p>
             </div>
             <h2 className="mt-1 text-base font-bold sm:text-lg">
                 {series.name}
@@ -53,7 +53,7 @@ export default function SeriesNav({
                                     'flex size-6 flex-none items-center justify-center rounded-full text-xs font-semibold',
                                     part.isCurrent
                                         ? 'bg-linear-to-br from-[var(--accent-from)] to-[var(--accent-to)] text-white'
-                                        : 'border-foreground/15 text-foreground/55 border'
+                                        : 'border-foreground/15 text-foreground/70 border'
                                 )}
                             >
                                 {index + 1}

--- a/src/components/pages/articles/TableOfContents/MobileTableOfContents.tsx
+++ b/src/components/pages/articles/TableOfContents/MobileTableOfContents.tsx
@@ -32,10 +32,10 @@ export default function MobileTableOfContents({
             className="border-foreground/10 bg-foreground/[0.02] group mb-8 rounded-xl border lg:hidden"
         >
             <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold [&::-webkit-details-marker]:hidden">
-                <span className="text-foreground/45 text-xs tracking-[0.12em] uppercase">
+                <span className="text-foreground/60 text-xs tracking-[0.12em] uppercase">
                     On this page
                 </span>
-                <ChevronIcon className="text-foreground/50 size-4 transition-transform group-open:rotate-180" />
+                <ChevronIcon className="text-foreground/70 size-4 transition-transform group-open:rotate-180" />
             </summary>
             <div className="px-3 pb-3">
                 <TocList

--- a/src/components/pages/articles/TableOfContents/TocList.tsx
+++ b/src/components/pages/articles/TableOfContents/TocList.tsx
@@ -31,7 +31,7 @@ export default function TocList({
                                 item.level === 3 ? 'pl-5' : 'pl-2',
                                 isActive
                                     ? 'text-[var(--accent-to)]'
-                                    : 'text-foreground/55 hover:text-foreground'
+                                    : 'text-foreground/70 hover:text-foreground'
                             )}
                         >
                             <span

--- a/src/components/pages/articles/TableOfContents/index.tsx
+++ b/src/components/pages/articles/TableOfContents/index.tsx
@@ -33,7 +33,7 @@ export default function TableOfContents({
             style={accentStyle(accentColors)}
             className="sticky top-24 hidden max-h-[calc(100vh-8rem)] overflow-y-auto lg:block"
         >
-            <p className="text-foreground/45 mb-3 text-xs font-semibold tracking-[0.12em] uppercase">
+            <p className="text-foreground/60 mb-3 text-xs font-semibold tracking-[0.12em] uppercase">
                 On this page
             </p>
             <TocList

--- a/src/components/pages/articles/TechStack.tsx
+++ b/src/components/pages/articles/TechStack.tsx
@@ -17,7 +17,7 @@ export default function TechStack({
 
     return (
         <div className={cn('flex flex-wrap items-center gap-2', className)}>
-            <span className="text-foreground/45 text-xs font-semibold tracking-[0.1em] uppercase">
+            <span className="text-foreground/60 text-xs font-semibold tracking-[0.1em] uppercase">
                 Stack
             </span>
             <ul className="flex flex-wrap gap-2">

--- a/src/components/pages/articles/WhatYoullLearn.tsx
+++ b/src/components/pages/articles/WhatYoullLearn.tsx
@@ -34,7 +34,7 @@ export default function WhatYoullLearn({
             />
             <h2
                 id="what-youll-learn"
-                className="text-foreground/45 text-xs font-semibold tracking-[0.12em] uppercase"
+                className="text-foreground/60 text-xs font-semibold tracking-[0.12em] uppercase"
             >
                 What you&rsquo;ll learn
             </h2>

--- a/src/components/pages/home/ArticlesArea/index.tsx
+++ b/src/components/pages/home/ArticlesArea/index.tsx
@@ -29,7 +29,7 @@ export default function ArticlesArea() {
                 <div className="mt-10">
                     <Link
                         href="/articles"
-                        className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-2.5 text-sm transition-all duration-300 hover:scale-105"
+                        className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-2.5 text-sm transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
                     >
                         View all articles
                     </Link>

--- a/src/components/pages/home/ContactArea/ContactAside.tsx
+++ b/src/components/pages/home/ContactArea/ContactAside.tsx
@@ -1,4 +1,5 @@
 import { siteAuthorEmail } from '@/config/constants';
+import SectionHeading from '@/components/pages/common/SectionHeading';
 import StatusDot from '@/components/pages/home/ContactArea/StatusDot';
 import {
     asideEyebrow,
@@ -17,12 +18,15 @@ export default function ContactAside() {
     return (
         <div className="flex flex-col gap-6 text-left">
             <div className="flex flex-col gap-3">
-                <span className="text-foreground/45 text-xs font-semibold tracking-[0.22em] uppercase">
+                <span className="text-foreground/60 text-xs font-semibold tracking-[0.22em] uppercase">
                     {asideEyebrow}
                 </span>
-                <p className="text-2xl leading-snug font-semibold text-balance">
+                <SectionHeading
+                    as="h2"
+                    className="text-2xl leading-snug font-semibold text-balance sm:text-2xl"
+                >
                     {asideHeadline}
-                </p>
+                </SectionHeading>
                 <p className="text-foreground/65 text-sm leading-relaxed">
                     {asideBody}
                 </p>
@@ -31,7 +35,7 @@ export default function ContactAside() {
             <StatusDot label={availabilityLabel} />
 
             <div className="border-foreground/10 mt-auto border-t pt-5 text-sm">
-                <span className="text-foreground/50">{directEmailLead}</span>
+                <span className="text-foreground/70">{directEmailLead}</span>
                 <a
                     href={`mailto:${siteAuthorEmail}`}
                     className="decoration-emerald-500/40 hover:decoration-emerald-500 mt-1 block font-medium break-all underline underline-offset-4 transition-colors"

--- a/src/components/pages/home/ContactArea/ContactForm.tsx
+++ b/src/components/pages/home/ContactArea/ContactForm.tsx
@@ -20,7 +20,7 @@ import {
 const fieldAccentClassName =
     'focus:border-emerald-500/60 focus:ring-2 focus:ring-emerald-500/15';
 const fieldLabelClassName =
-    'text-foreground/50 text-[0.7rem] font-semibold tracking-[0.14em] uppercase';
+    'text-foreground/70 text-xs font-semibold tracking-[0.14em] uppercase';
 
 export default function ContactForm() {
     const { setContainer, token, reset: resetCaptcha } = useHCaptcha();
@@ -129,7 +129,7 @@ export default function ContactForm() {
                                         )}
                                     </Button>
                                     {!token && (
-                                        <span className="text-foreground/50 text-xs">
+                                        <span className="text-foreground/70 text-xs">
                                             Complete the captcha to enable
                                             sending.
                                         </span>

--- a/src/components/pages/home/HeroArea/ScrollDownCue.tsx
+++ b/src/components/pages/home/HeroArea/ScrollDownCue.tsx
@@ -19,7 +19,7 @@ export default function ScrollDownCue() {
             href="#about"
             aria-label="Scroll to the about section"
             className={cn(
-                'text-foreground/40 hover:text-foreground/70 mb-6 transition-all duration-500 ease-out motion-reduce:transition-none motion-safe:animate-bounce sm:mb-10',
+                'text-foreground/55 hover:text-foreground/70 mb-6 transition-all duration-500 ease-out motion-reduce:transition-none motion-safe:animate-bounce sm:mb-10',
                 navbarVisible
                     ? 'pointer-events-none invisible opacity-0'
                     : 'visible opacity-100'

--- a/src/components/pages/home/HeroArea/SocialIcons.tsx
+++ b/src/components/pages/home/HeroArea/SocialIcons.tsx
@@ -13,7 +13,7 @@ export default function SocialIcons() {
                     title={name}
                     aria-label={name}
                     className={cn(
-                        'p-2 transition-all duration-300 hover:scale-110',
+                        'p-2 transition-[color,transform] duration-300 motion-safe:hover:scale-110',
                         socialColorClassNames
                     )}
                 >

--- a/src/components/pages/home/ProjectsArea/index.tsx
+++ b/src/components/pages/home/ProjectsArea/index.tsx
@@ -27,7 +27,7 @@ export default function ProjectsArea() {
                     <ProjectGrid projects={packageProjects} />
                 </div>
 
-                <div className="mt-14 space-y-6">
+                <div className="mt-12 space-y-6">
                     <h3 className="text-foreground/60 text-center text-sm font-bold tracking-wider uppercase">
                         Personal Projects
                     </h3>

--- a/src/components/pages/home/SkillsArea/SkillCard/index.tsx
+++ b/src/components/pages/home/SkillsArea/SkillCard/index.tsx
@@ -29,7 +29,7 @@ export default function SkillCard({ skill }: { skill: Skill }) {
         >
             <Icon
                 className={cn(
-                    'text-foreground/45 size-7 shrink-0 transition-colors duration-300',
+                    'text-foreground/60 size-7 shrink-0 transition-colors duration-300',
                     color
                         ? 'group-hover:[color:var(--brand-color)]'
                         : 'group-hover:text-foreground'

--- a/src/components/pages/now/NowBlock.tsx
+++ b/src/components/pages/now/NowBlock.tsx
@@ -18,7 +18,7 @@ export default function NowBlock({ block }: { block: NowBlockData }) {
             return <BulletList items={block.items} />;
         case 'text':
             return (
-                <p className="text-foreground/70 text-sm leading-relaxed">
+                <p className="text-foreground/70 max-w-3xl text-base leading-relaxed">
                     {block.text}
                 </p>
             );

--- a/src/components/pages/now/NowCard/index.tsx
+++ b/src/components/pages/now/NowCard/index.tsx
@@ -33,13 +33,13 @@ export default function NowCard({
             style={accent}
             className={cn(
                 styles.card,
-                'group border-foreground/10 hover:border-foreground/25 relative isolate flex h-full flex-col rounded-2xl border p-6 transition-all duration-300 hover:shadow-lg sm:p-7',
+                'group border-foreground/10 hover:border-foreground/25 relative isolate flex h-full flex-col rounded-2xl border p-6 transition-[border-color,box-shadow] duration-300 hover:shadow-lg sm:p-8',
                 section.wide && 'md:col-span-2'
             )}
         >
             <span
                 aria-hidden="true"
-                className="text-foreground/25 group-hover:text-foreground/45 absolute top-5 right-6 font-mono text-xs tracking-widest transition-colors duration-300 sm:top-6"
+                className="text-foreground/25 group-hover:text-foreground/60 absolute top-5 right-6 font-mono text-xs tracking-widest transition-colors duration-300 sm:top-6"
             >
                 {catalogNumber}
             </span>

--- a/src/components/pages/now/NowGrid.tsx
+++ b/src/components/pages/now/NowGrid.tsx
@@ -15,7 +15,7 @@ export default function NowGrid({
     sections: NowSectionData[];
 }) {
     return (
-        <ul className="grid grid-flow-row-dense gap-4 sm:gap-5 md:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid grid-flow-row-dense gap-6 md:grid-cols-2 lg:grid-cols-3">
             {sections.map((section, index) => (
                 <NowCard
                     key={section.title}

--- a/src/components/pages/resume/BulletList.tsx
+++ b/src/components/pages/resume/BulletList.tsx
@@ -21,7 +21,7 @@ export default function BulletList({
                 >
                     <span
                         aria-hidden="true"
-                        className="text-foreground/40 select-none print:text-black"
+                        className="text-foreground/55 select-none print:text-black"
                     >
                         •
                     </span>

--- a/src/components/pages/resume/MetaText.tsx
+++ b/src/components/pages/resume/MetaText.tsx
@@ -15,7 +15,7 @@ export default function MetaText({
     return (
         <span
             className={cn(
-                'text-foreground/50 font-mono text-[11px] print:font-[Helvetica,Arial,sans-serif] print:text-[9pt] print:text-black/70',
+                'text-foreground/70 font-mono text-[11px] print:font-[Helvetica,Arial,sans-serif] print:text-[9pt] print:text-black/70',
                 className
             )}
         >

--- a/src/components/pages/resume/ProjectItem.tsx
+++ b/src/components/pages/resume/ProjectItem.tsx
@@ -22,7 +22,7 @@ export default function ProjectItem({ entry }: { entry: ProjectEntry }) {
                     <>
                         <span
                             aria-hidden="true"
-                            className="text-foreground/40"
+                            className="text-foreground/55"
                         >
                             {' · '}
                         </span>
@@ -34,7 +34,7 @@ export default function ProjectItem({ entry }: { entry: ProjectEntry }) {
             </h3>
 
             {entry.company && (
-                <p className="text-foreground/55 mt-0.5 text-[12px] font-medium print:text-[9pt]">
+                <p className="text-foreground/70 mt-0.5 text-[12px] font-medium print:text-[9pt]">
                     {entry.company}
                 </p>
             )}

--- a/src/components/pages/resume/ResumeSection.tsx
+++ b/src/components/pages/resume/ResumeSection.tsx
@@ -14,7 +14,7 @@ export default function ResumeSection({
 }) {
     return (
         <section>
-            <h2 className="border-foreground/15 text-foreground/55 mb-3 border-b pb-1.5 font-mono text-[10px] font-semibold tracking-[0.2em] uppercase print:mb-2 print:pb-1 print:font-[Helvetica,Arial,sans-serif] print:text-[9.5pt] print:font-bold print:tracking-[0.06em] print:text-black">
+            <h2 className="border-foreground/15 text-foreground/70 mb-3 border-b pb-1.5 font-mono text-[10px] font-semibold tracking-[0.2em] uppercase print:mb-2 print:pb-1 print:font-[Helvetica,Arial,sans-serif] print:text-[9.5pt] print:font-bold print:tracking-[0.06em] print:text-black">
                 {label}
             </h2>
             {children}

--- a/src/components/pages/uses/SpecList.tsx
+++ b/src/components/pages/uses/SpecList.tsx
@@ -21,7 +21,7 @@ export default function SpecList({ label, specs }: SpecListProps) {
             <dl className="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-x-6 gap-y-4">
                 {specs.map((spec) => (
                     <div key={spec.label}>
-                        <dt className="text-foreground/50 text-[0.7rem] font-semibold tracking-wide uppercase">
+                        <dt className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">
                             {spec.label}
                         </dt>
                         <dd className="text-foreground/90 mt-1 font-mono text-sm leading-snug">

--- a/src/components/pages/uses/UsesCard/index.tsx
+++ b/src/components/pages/uses/UsesCard/index.tsx
@@ -32,13 +32,13 @@ export default function UsesCard({
             style={accent}
             className={cn(
                 styles.card,
-                'group border-foreground/10 hover:border-foreground/25 relative isolate flex h-full flex-col rounded-2xl border p-6 transition-all duration-300 hover:shadow-lg sm:p-7',
+                'group border-foreground/10 hover:border-foreground/25 relative isolate flex h-full flex-col rounded-2xl border p-6 transition-[border-color,box-shadow] duration-300 hover:shadow-lg sm:p-8',
                 section.wide && 'md:col-span-2'
             )}
         >
             <span
                 aria-hidden="true"
-                className="text-foreground/25 group-hover:text-foreground/45 absolute top-5 right-6 font-mono text-xs tracking-widest transition-colors duration-300 sm:top-6"
+                className="text-foreground/25 group-hover:text-foreground/60 absolute top-5 right-6 font-mono text-xs tracking-widest transition-colors duration-300 sm:top-6"
             >
                 {catalogNumber}
             </span>

--- a/src/components/pages/uses/UsesGrid.tsx
+++ b/src/components/pages/uses/UsesGrid.tsx
@@ -15,7 +15,7 @@ export default function UsesGrid({
     sections: UsesSectionData[];
 }) {
     return (
-        <ul className="grid grid-flow-row-dense gap-4 sm:gap-5 md:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid grid-flow-row-dense gap-6 md:grid-cols-2 lg:grid-cols-3">
             {sections.map((section, index) => (
                 <UsesCard
                     key={section.title}

--- a/src/components/pwa/UpdateToast/index.tsx
+++ b/src/components/pwa/UpdateToast/index.tsx
@@ -28,7 +28,7 @@ export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
         >
             <span
                 aria-hidden
-                className="bg-foreground/40 size-1.5 shrink-0 animate-pulse rounded-full"
+                className="bg-foreground/40 size-1.5 shrink-0 rounded-full motion-safe:animate-pulse"
             />
             <p className="text-sm font-medium whitespace-nowrap">
                 Update available
@@ -44,7 +44,7 @@ export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
                 type="button"
                 onClick={onDismiss}
                 aria-label="Dismiss"
-                className="text-foreground/50 hover:bg-foreground/10 hover:text-foreground flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-lg leading-none transition-colors"
+                className="text-foreground/70 hover:bg-foreground/10 hover:text-foreground flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-lg leading-none transition-colors"
             >
                 &times;
             </button>

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -4,7 +4,7 @@ import Spinner from '@/components/ui/Spinner';
 export type ButtonVariant = 'primary' | 'outline';
 
 const buttonBaseClassName =
-    'inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors';
+    'inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:ring-foreground/50 focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none';
 
 const variantClassNames: Record<ButtonVariant, string> = {
     primary:

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -2,7 +2,7 @@ import { useId } from 'react';
 import { cn } from '@/utils/cn';
 
 export const fieldControlClassName =
-    'border-foreground/15 bg-background/60 w-full rounded-xl border px-3.5 py-2.5 text-sm outline-none transition focus:border-foreground/40';
+    'border-foreground/15 bg-background/60 focus:border-foreground/40 focus:ring-foreground/20 w-full rounded-xl border px-3.5 py-2.5 text-sm outline-none transition focus:ring-2';
 
 type InputProps = React.ComponentPropsWithRef<'input'> & {
     label: string;


### PR DESCRIPTION
Accessibility:
- add a global prefers-reduced-motion reset so ungated inline transition and animate utilities collapse for reduced-motion users
- gate the update-toast pulse and card scale-hovers behind motion-safe
- raise muted text-foreground levels to meet WCAG AA in both themes (eyebrows to /60, secondary to /70, placeholders/icons to /55)
- make inline-code crimson theme-aware so it clears AA in light and dark
- add visible focus-visible rings to the shared Button and Input/Textarea
- give the Contact section a semantic h2 via the shared SectionHeading

Consistency:
- convert ArticleCard to the signature radial bloom, spilling from below the cover thumbnail instead of a flat linear wash
- align bento cards and grids to the 8pt scale (p-8, gap-6)
- unify eyebrow label sizing to text-xs
- fix /now body copy to 16px to match its /uses sibling
- narrow transition-all to explicit properties on the affected surfaces