### PR TITLE
fix(ui): sitewide accessibility, touch, and consistency polish

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,32 +1,34 @@
 'use client';
 
-import Link from 'next/link';
+import GridBackground from '@/components/backgrounds/GridBackground';
+import Button from '@/components/ui/Button';
+import ButtonLink from '@/components/ui/ButtonLink';
 import SectionHeading from '@/components/pages/common/SectionHeading';
 
-// Client error boundary for runtime render errors on the exported site. Kept
-// thin, reusing the shared heading and the site's CTA link/button styling.
+// Client error boundary for runtime render errors on the exported site. Echoes
+// the site's hero motif (grid backdrop) and reuses the shared button styling so
+// the error surface reads as part of the site, not a bare fallback.
 export default function Error({ reset }: { error: Error; reset: () => void }) {
     return (
-        <main className="container mx-auto flex flex-col items-center px-4 py-28 text-center sm:py-36">
+        <main
+            id="main"
+            className="relative isolate flex grow flex-col items-center justify-center overflow-hidden px-4 py-28 text-center sm:py-36"
+        >
+            <GridBackground className="opacity-60" />
+
             <SectionHeading as="h1">Something went wrong</SectionHeading>
-            <p className="text-foreground/70 mt-4 max-w-xl text-lg leading-relaxed">
+            <p className="text-foreground/70 mt-4 max-w-xl text-lg leading-relaxed text-balance">
                 An unexpected error interrupted this page. You can try again, or
                 head back home.
             </p>
             <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-                <button
-                    type="button"
+                <Button
+                    variant="outline"
                     onClick={reset}
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
                 >
                     Try again
-                </button>
-                <Link
-                    href="/"
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
-                >
-                    Back home
-                </Link>
+                </Button>
+                <ButtonLink href="/">Back home</ButtonLink>
             </div>
         </main>
     );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,11 @@
     color-scheme: light dark;
     --background: #ededed;
     --foreground: #171717;
+    /* Decorative grid/dot backdrop lines, derived from the foreground token so
+       they stay subtle and flip with the theme (dark lines on light, light lines
+       on dark) instead of a fixed gray. Consumed by GridBackground/DotBackground. */
+    --grid-line: color-mix(in oklab, var(--foreground) 13%, transparent);
+    --grid-dot: color-mix(in oklab, var(--foreground) 22%, transparent);
     --section-swell-indigo: #e9e9f0;
     --section-swell-blue: #e7ebf2;
     --section-swell-yellow: #f0eee4;
@@ -275,4 +280,13 @@ body {
         --text-box-edge- *,
         --global-value- *
     );
+}
+
+/* Shared keyboard focus ring. One definition so every interactive surface, the
+   nav/theme chrome, breadcrumb and article links, buttons and form controls,
+   shows the same visible focus indicator instead of a per-component mix of the
+   UA outline and bespoke rings. Uses focus-visible so it only appears for
+   keyboard users. Compose with `cn(styles..., 'focus-ring')` or apply directly. */
+@utility focus-ring {
+    @apply focus-visible:ring-foreground/50 focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -98,7 +98,12 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-    themeColor: 'white',
+    // Match the browser chrome to the resolved theme's background token instead
+    // of a fixed white, so the mobile status bar stays on-theme in dark mode.
+    themeColor: [
+        { media: '(prefers-color-scheme: light)', color: '#ededed' },
+        { media: '(prefers-color-scheme: dark)', color: '#0a0a0a' },
+    ],
 };
 
 export default function RootLayout({
@@ -137,6 +142,15 @@ export default function RootLayout({
             <body
                 className={`${notoSans.variable} bg-background relative flex min-h-svh flex-col text-base antialiased print:bg-white!`}
             >
+                {/* Skip link: the first focusable element, visually hidden until
+                    focused, so keyboard and screen-reader users can bypass the
+                    fixed nav and jump straight to each page's <main id="main">. */}
+                <a
+                    href="#main"
+                    className="focus-ring sr-only focus:not-sr-only focus:bg-background focus:text-foreground focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:shadow-lg print:hidden"
+                >
+                    Skip to content
+                </a>
                 <PageGradientProvider>
                     <PageGradientBackground />
                     <HashScroll />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,12 +1,19 @@
-import Link from 'next/link';
+import GridBackground from '@/components/backgrounds/GridBackground';
+import ButtonLink from '@/components/ui/ButtonLink';
 import SectionHeading from '@/components/pages/common/SectionHeading';
 
 // Statically exported to out/404.html, which GitHub Pages serves for any unknown
-// path. Kept thin, reusing the shared heading and the site's CTA link styling.
+// path. Echoes the site's hero motif (grid backdrop) and reuses the shared
+// button styling so the 404 reads as part of the site.
 export default function NotFound() {
     return (
-        <main className="container mx-auto flex flex-col items-center px-4 py-28 text-center sm:py-36">
-            <p className="text-foreground/50 text-6xl font-bold sm:text-7xl">
+        <main
+            id="main"
+            className="relative isolate flex grow flex-col items-center justify-center overflow-hidden px-4 py-28 text-center sm:py-36"
+        >
+            <GridBackground className="opacity-60" />
+
+            <p className="text-foreground/70 text-6xl font-bold sm:text-7xl">
                 404
             </p>
             <SectionHeading
@@ -15,23 +22,18 @@ export default function NotFound() {
             >
                 This page wandered off
             </SectionHeading>
-            <p className="text-foreground/70 mt-4 max-w-xl text-lg leading-relaxed">
+            <p className="text-foreground/70 mt-4 max-w-xl text-lg leading-relaxed text-balance">
                 The page you are looking for does not exist, moved, or never did.
                 Let&apos;s get you back on track.
             </p>
             <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-                <Link
-                    href="/"
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
-                >
-                    Back home
-                </Link>
-                <Link
+                <ButtonLink href="/">Back home</ButtonLink>
+                <ButtonLink
                     href="/articles"
-                    className="border-foreground/20 hover:border-foreground/50 inline-block rounded-full border px-6 py-3 text-base transition-[transform,border-color] duration-300 motion-safe:hover:scale-105"
+                    variant="outline"
                 >
                     Read articles
-                </Link>
+                </ButtonLink>
             </div>
         </main>
     );

--- a/src/app/now/contents.ts
+++ b/src/app/now/contents.ts
@@ -1,4 +1,11 @@
 import type { NowSectionData } from '@/components/pages/now/types';
+import Briefcase from '@/components/icons/briefcase';
+import Bot from '@/components/icons/bot';
+import BookOpen from '@/components/icons/book-open';
+import Server from '@/components/icons/server';
+import Pencil from '@/components/icons/pencil';
+import Book from '@/components/icons/book';
+import Target from '@/components/icons/target';
 
 export const nowMeta = {
     title: "What I'm Doing Now",
@@ -10,7 +17,7 @@ export const nowMeta = {
 export const nowSections: NowSectionData[] = [
     {
         title: 'Work',
-        emoji: '👨‍💻',
+        Icon: Briefcase,
         intro: 'Currently working as a Senior Software Engineer, building scalable web applications and backend systems. My daily work focuses on:',
         blocks: [
             {
@@ -28,7 +35,7 @@ export const nowSections: NowSectionData[] = [
     },
     {
         title: 'Building',
-        emoji: '🤖',
+        Icon: Bot,
         intro: 'Exploring practical AI applications. Current interests:',
         wide: true,
         blocks: [
@@ -48,7 +55,7 @@ export const nowSections: NowSectionData[] = [
     },
     {
         title: 'Learning',
-        emoji: '📚',
+        Icon: BookOpen,
         intro: "I'm currently investing time in becoming a stronger backend engineer. Topics I'm studying:",
         blocks: [
             {
@@ -67,7 +74,7 @@ export const nowSections: NowSectionData[] = [
     },
     {
         title: 'Home Lab',
-        emoji: '🏠',
+        Icon: Server,
         intro: "I'm constantly experimenting with my self-hosted infrastructure. Current playground:",
         outro: 'I enjoy building infrastructure almost as much as building applications.',
         wide: true,
@@ -88,7 +95,7 @@ export const nowSections: NowSectionData[] = [
     },
     {
         title: 'Writing',
-        emoji: '📝',
+        Icon: Pencil,
         intro: 'Working on documenting what I learn. Topics I want to write about:',
         blocks: [
             {
@@ -108,7 +115,7 @@ export const nowSections: NowSectionData[] = [
     },
     {
         title: 'Reading',
-        emoji: '📖',
+        Icon: Book,
         intro: 'Books currently on my reading list:',
         blocks: [
             {
@@ -124,7 +131,7 @@ export const nowSections: NowSectionData[] = [
     },
     {
         title: 'Goals',
-        emoji: '🎯',
+        Icon: Target,
         intro: 'Current goals include:',
         blocks: [
             {

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -15,14 +15,17 @@ export const metadata = buildPageMetadata({
 
 export default function NowPage() {
     return (
-        <main className="container mx-auto px-4 py-20 sm:py-28">
+        <main
+            id="main"
+            className="container mx-auto px-4 py-20 sm:py-28"
+        >
             <Breadcrumb />
             <SectionHeading as="h1">{nowMeta.title}</SectionHeading>
             <p className="text-foreground/70 mt-6 max-w-3xl text-lg leading-relaxed">
                 {nowMeta.subtitle}
             </p>
 
-            <p className="border-foreground/10 text-foreground/60 mt-6 inline-flex items-center gap-2.5 rounded-full border py-1.5 pr-4 pl-3 text-sm">
+            <p className="border-foreground/10 text-foreground/70 mt-6 inline-flex items-center gap-2.5 rounded-full border py-1.5 pr-4 pl-3 text-sm">
                 <span
                     aria-hidden="true"
                     className="relative grid size-2 place-items-center"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,10 @@ import SectionUrlSync from '@/components/layout/SectionUrlSync';
 
 export default function Home() {
     return (
-        <main className="home-sections">
+        <main
+            id="main"
+            className="home-sections"
+        >
             <SectionUrlSync />
 
             <HeroArea />

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -58,6 +58,7 @@ export default function ResumePage() {
         // inherit and win over :root[data-theme='dark']), so all `text-foreground`
         // prints dark-on-white; browsers already drop backgrounds in print.
         <main
+            id="main"
             className={cn(
                 jetBrainsMono.variable,
                 'container mx-auto px-4 py-20 sm:py-28',

--- a/src/app/uses/contents.ts
+++ b/src/app/uses/contents.ts
@@ -1,9 +1,20 @@
 import type { UsesSectionData } from '@/components/pages/uses/types';
+import Cpu from '@/components/icons/cpu';
+import Monitor from '@/components/icons/monitor';
+import Keyboard from '@/components/icons/keyboard';
+import Mouse from '@/components/icons/mouse';
+import Speaker from '@/components/icons/speaker';
+import Server from '@/components/icons/server';
+import Cloud from '@/components/icons/cloud';
+import Code from '@/components/icons/code';
+import Bot from '@/components/icons/bot';
+import Box from '@/components/icons/box';
+import Wrench from '@/components/icons/wrench';
 
 export const usesSections: UsesSectionData[] = [
     {
         title: 'Development Workstation',
-        emoji: '💻',
+        Icon: Cpu,
         intro: 'My primary machine for software development, AI experimentation, and gaming.',
         wide: true,
         blocks: [
@@ -39,7 +50,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Displays',
-        emoji: '🖥️',
+        Icon: Monitor,
         blocks: [
             {
                 kind: 'specs',
@@ -58,7 +69,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Keyboards',
-        emoji: '⌨️',
+        Icon: Keyboard,
         blocks: [
             {
                 kind: 'gear',
@@ -79,7 +90,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Mouse',
-        emoji: '🖱️',
+        Icon: Mouse,
         blocks: [
             {
                 kind: 'gear',
@@ -95,7 +106,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Audio',
-        emoji: '🔊',
+        Icon: Speaker,
         intro: 'Perfect for music while coding, online meetings, and watching technical talks.',
         blocks: [
             {
@@ -106,7 +117,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Home Lab',
-        emoji: '🏠',
+        Icon: Server,
         intro: 'One of my favorite projects is my self-hosted home lab, where I experiment with infrastructure, networking, virtualization, automation, and self-hosting technologies.',
         wide: true,
         blocks: [
@@ -148,7 +159,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Cloud Infrastructure',
-        emoji: '☁️',
+        Icon: Cloud,
         intro: 'Alongside my home lab, I maintain a cloud server that hosts public-facing services and securely connects to my home network.',
         blocks: [
             {
@@ -174,7 +185,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Development',
-        emoji: '👨‍💻',
+        Icon: Code,
         wide: true,
         blocks: [
             {
@@ -217,7 +228,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'AI',
-        emoji: '🤖',
+        Icon: Bot,
         intro: 'AI has become part of my daily development workflow.',
         blocks: [
             {
@@ -243,7 +254,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Infrastructure & DevOps',
-        emoji: '🐳',
+        Icon: Box,
         blocks: [
             {
                 kind: 'tags',
@@ -269,7 +280,7 @@ export const usesSections: UsesSectionData[] = [
     },
     {
         title: 'Developer Tools',
-        emoji: '🛠️',
+        Icon: Wrench,
         wide: true,
         blocks: [
             {

--- a/src/app/uses/page.tsx
+++ b/src/app/uses/page.tsx
@@ -15,7 +15,10 @@ export const metadata = buildPageMetadata({
 
 export default function UsesPage() {
     return (
-        <main className="container mx-auto px-4 py-20 sm:py-28">
+        <main
+            id="main"
+            className="container mx-auto px-4 py-20 sm:py-28"
+        >
             <Breadcrumb />
             <SectionHeading as="h1">Uses</SectionHeading>
             <p className="text-foreground/70 mt-6 max-w-3xl text-lg leading-relaxed">

--- a/src/components/backgrounds/DotBackground.tsx
+++ b/src/components/backgrounds/DotBackground.tsx
@@ -1,5 +1,5 @@
 export default function DotBackground() {
     return (
-        <div className="absolute inset-0 -z-10 h-full w-full bg-[radial-gradient(circle,#73737350_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_80%,transparent_100%)] bg-[size:10px_10px]" />
+        <div className="absolute inset-0 -z-10 h-full w-full bg-[radial-gradient(circle,var(--grid-dot)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_80%,transparent_100%)] bg-[size:10px_10px]" />
     );
 }

--- a/src/components/backgrounds/GridBackground.tsx
+++ b/src/components/backgrounds/GridBackground.tsx
@@ -8,7 +8,7 @@ export default function GridBackground(
     return (
         <div
             className={cn(
-                'absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#73737320_1px,transparent_1px),linear-gradient(to_bottom,#73737320_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_80%,transparent_100%)] bg-size-[20px_20px]',
+                'absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,var(--grid-line)_1px,transparent_1px),linear-gradient(to_bottom,var(--grid-line)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_80%,transparent_100%)] bg-size-[20px_20px]',
                 className
             )}
             {...rest}

--- a/src/components/icons/book-open.tsx
+++ b/src/components/icons/book-open.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/cn';
+
+export default function BookOpen({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M12 7v14" />
+            <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+        </svg>
+    );
+}

--- a/src/components/icons/book.tsx
+++ b/src/components/icons/book.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/cn';
+
+export default function Book({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        </svg>
+    );
+}

--- a/src/components/icons/bot.tsx
+++ b/src/components/icons/bot.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/utils/cn';
+
+export default function Bot({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M12 8V4H8" />
+            <rect
+                width="16"
+                height="12"
+                x="4"
+                y="8"
+                rx="2"
+            />
+            <path d="M2 14h2" />
+            <path d="M20 14h2" />
+            <path d="M15 13v2" />
+            <path d="M9 13v2" />
+        </svg>
+    );
+}

--- a/src/components/icons/box.tsx
+++ b/src/components/icons/box.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/utils/cn';
+
+export default function Box({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+            <path d="m3.3 7 8.7 5 8.7-5" />
+            <path d="M12 22V12" />
+        </svg>
+    );
+}

--- a/src/components/icons/briefcase.tsx
+++ b/src/components/icons/briefcase.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/utils/cn';
+
+export default function Briefcase({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M16 20V4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+            <rect
+                width="20"
+                height="14"
+                x="2"
+                y="6"
+                rx="2"
+            />
+        </svg>
+    );
+}

--- a/src/components/icons/close.tsx
+++ b/src/components/icons/close.tsx
@@ -6,7 +6,7 @@ export default function Close({
 }: React.SVGProps<SVGSVGElement>) {
     return (
         <svg
-            className={cn('', className)}
+            className={cn('size-5', className)}
             {...rest}
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/icons/cloud.tsx
+++ b/src/components/icons/cloud.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/utils/cn';
+
+export default function Cloud({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z" />
+        </svg>
+    );
+}

--- a/src/components/icons/code.tsx
+++ b/src/components/icons/code.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/cn';
+
+export default function Code({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="m16 18 6-6-6-6" />
+            <path d="m8 6-6 6 6 6" />
+        </svg>
+    );
+}

--- a/src/components/icons/cpu.tsx
+++ b/src/components/icons/cpu.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/utils/cn';
+
+export default function Cpu({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <rect
+                width="16"
+                height="16"
+                x="4"
+                y="4"
+                rx="2"
+            />
+            <rect
+                width="6"
+                height="6"
+                x="9"
+                y="9"
+                rx="1"
+            />
+            <path d="M15 2v2" />
+            <path d="M15 20v2" />
+            <path d="M2 15h2" />
+            <path d="M2 9h2" />
+            <path d="M20 15h2" />
+            <path d="M20 9h2" />
+            <path d="M9 2v2" />
+            <path d="M9 20v2" />
+        </svg>
+    );
+}

--- a/src/components/icons/keyboard.tsx
+++ b/src/components/icons/keyboard.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/utils/cn';
+
+export default function Keyboard({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <rect
+                width="20"
+                height="16"
+                x="2"
+                y="4"
+                rx="2"
+            />
+            <path d="M6 8h.01" />
+            <path d="M10 8h.01" />
+            <path d="M14 8h.01" />
+            <path d="M18 8h.01" />
+            <path d="M8 12h.01" />
+            <path d="M12 12h.01" />
+            <path d="M16 12h.01" />
+            <path d="M7 16h10" />
+        </svg>
+    );
+}

--- a/src/components/icons/menu.tsx
+++ b/src/components/icons/menu.tsx
@@ -6,7 +6,7 @@ export default function Menu({
 }: React.SVGProps<SVGSVGElement>) {
     return (
         <svg
-            className={cn('', className)}
+            className={cn('size-5', className)}
             {...rest}
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/icons/monitor.tsx
+++ b/src/components/icons/monitor.tsx
@@ -6,7 +6,7 @@ export default function Monitor({
 }: React.SVGProps<SVGSVGElement>) {
     return (
         <svg
-            className={cn('', className)}
+            className={cn('size-5', className)}
             {...rest}
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/icons/moon.tsx
+++ b/src/components/icons/moon.tsx
@@ -6,7 +6,7 @@ export default function Moon({
 }: React.SVGProps<SVGSVGElement>) {
     return (
         <svg
-            className={cn('', className)}
+            className={cn('size-5', className)}
             {...rest}
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/icons/mouse.tsx
+++ b/src/components/icons/mouse.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/utils/cn';
+
+export default function Mouse({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <rect
+                width="14"
+                height="20"
+                x="5"
+                y="2"
+                rx="7"
+            />
+            <path d="M12 6v4" />
+        </svg>
+    );
+}

--- a/src/components/icons/pencil.tsx
+++ b/src/components/icons/pencil.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/cn';
+
+export default function Pencil({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z" />
+            <path d="m15 5 4 4" />
+        </svg>
+    );
+}

--- a/src/components/icons/server.tsx
+++ b/src/components/icons/server.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/utils/cn';
+
+export default function Server({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <rect
+                width="20"
+                height="8"
+                x="2"
+                y="2"
+                rx="2"
+            />
+            <rect
+                width="20"
+                height="8"
+                x="2"
+                y="14"
+                rx="2"
+            />
+            <path d="M6 6h.01" />
+            <path d="M6 18h.01" />
+        </svg>
+    );
+}

--- a/src/components/icons/speaker.tsx
+++ b/src/components/icons/speaker.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/utils/cn';
+
+export default function Speaker({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <rect
+                width="16"
+                height="20"
+                x="4"
+                y="2"
+                rx="2"
+            />
+            <path d="M12 6h.01" />
+            <circle
+                cx="12"
+                cy="14"
+                r="4"
+            />
+            <path d="M12 14h.01" />
+        </svg>
+    );
+}

--- a/src/components/icons/sun.tsx
+++ b/src/components/icons/sun.tsx
@@ -6,7 +6,7 @@ export default function Sun({
 }: React.SVGProps<SVGSVGElement>) {
     return (
         <svg
-            className={cn('', className)}
+            className={cn('size-5', className)}
             {...rest}
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/icons/target.tsx
+++ b/src/components/icons/target.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/utils/cn';
+
+export default function Target({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <circle
+                cx="12"
+                cy="12"
+                r="10"
+            />
+            <circle
+                cx="12"
+                cy="12"
+                r="6"
+            />
+            <circle
+                cx="12"
+                cy="12"
+                r="2"
+            />
+        </svg>
+    );
+}

--- a/src/components/icons/wrench.tsx
+++ b/src/components/icons/wrench.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/utils/cn';
+
+export default function Wrench({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+        </svg>
+    );
+}

--- a/src/components/layout/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/layout/Breadcrumb/BreadcrumbItem.tsx
@@ -25,7 +25,7 @@ export default function BreadcrumbItem({ item, isCurrent }: BreadcrumbItemProps)
             href={item.href}
             aria-label={item.name ?? item.label}
             className={cn(
-                'hover:text-foreground transition-colors motion-reduce:transition-none'
+                'focus-ring hover:text-foreground rounded-sm transition-colors motion-reduce:transition-none'
             )}
         >
             {item.label}

--- a/src/components/layout/Breadcrumb/index.tsx
+++ b/src/components/layout/Breadcrumb/index.tsx
@@ -57,7 +57,7 @@ export default function Breadcrumb({ currentName }: BreadcrumbProps) {
             aria-label="Breadcrumb"
             className={cn(
                 jetBrainsMono.variable,
-                'text-foreground/60 mb-6 font-mono text-sm sm:text-base'
+                'text-foreground/70 mb-6 font-mono text-sm sm:text-base'
             )}
         >
             <ol className="flex flex-wrap items-center gap-x-2 gap-y-1">

--- a/src/components/layout/Navbar/MobileMenuButton.tsx
+++ b/src/components/layout/Navbar/MobileMenuButton.tsx
@@ -16,9 +16,19 @@ export default function MobileMenuButton({
             aria-label={open ? 'Close menu' : 'Open menu'}
             aria-expanded={open}
             onClick={onToggle}
-            className="border-foreground/10 bg-background/60 text-foreground/80 hover:text-foreground relative flex size-11 items-center justify-center rounded-full border shadow-lg shadow-black/5 backdrop-blur-lg transition-colors"
+            className="focus-ring border-foreground/10 bg-background/60 text-foreground/80 hover:text-foreground relative flex size-11 cursor-pointer items-center justify-center rounded-full border shadow-lg shadow-black/5 backdrop-blur-lg transition-colors"
         >
-            {open ? <Close className="size-6" /> : <Menu className="size-6" />}
+            {open ? (
+                <Close
+                    aria-hidden="true"
+                    className="size-6"
+                />
+            ) : (
+                <Menu
+                    aria-hidden="true"
+                    className="size-6"
+                />
+            )}
         </button>
     );
 }

--- a/src/components/layout/Navbar/MobileMenuPanel.tsx
+++ b/src/components/layout/Navbar/MobileMenuPanel.tsx
@@ -44,7 +44,7 @@ export default function MobileMenuPanel({
                 // travel in, and the logo simply lives in the menu.
                 <NavLogo
                     onNavigate={onNavigate}
-                    className="text-foreground/80 hover:text-foreground hover:bg-foreground/5 flex items-center rounded-xl px-4 py-3 transition-colors"
+                    className="text-foreground/80 hover:text-foreground hover:bg-foreground/5 flex min-h-11 items-center rounded-xl px-4 py-3 transition-colors"
                 />
             ) : (
                 // Inner pages reserve the slot the shared wordmark animates into
@@ -91,7 +91,7 @@ export default function MobileMenuPanel({
                         aria-hidden="true"
                         className="bg-foreground/10 my-1 h-px"
                     />
-                    <p className="text-foreground/60 px-4 pt-1 pb-0.5 text-xs font-semibold tracking-wide uppercase">
+                    <p className="text-foreground/70 px-4 pt-1 pb-0.5 text-xs font-semibold tracking-wide uppercase">
                         Studio
                     </p>
                     <ul className="flex flex-col gap-0.5">
@@ -112,7 +112,7 @@ export default function MobileMenuPanel({
                 className="bg-foreground/10 my-1 h-px"
             />
             <div className="flex items-center justify-between px-4 py-2">
-                <span className="text-foreground/60 text-sm">Theme</span>
+                <span className="text-foreground/70 text-sm">Theme</span>
                 <ThemeToggle />
             </div>
         </nav>

--- a/src/components/layout/Navbar/NavItem.tsx
+++ b/src/components/layout/Navbar/NavItem.tsx
@@ -25,10 +25,10 @@ export default function NavItem({
     };
 
     const className = cn(
-        'block text-sm transition-colors',
+        'focus-ring block text-sm transition-colors',
         variant === 'pill'
             ? 'rounded-full px-2.5 py-1.5 lg:px-3'
-            : 'hover:bg-foreground/5 rounded-xl px-4 py-2.5',
+            : 'hover:bg-foreground/5 flex min-h-11 items-center rounded-xl px-4',
         active
             ? 'bg-foreground/10 text-foreground font-semibold'
             : 'text-foreground/70 hover:text-foreground'

--- a/src/components/layout/Navbar/NavLogo.tsx
+++ b/src/components/layout/Navbar/NavLogo.tsx
@@ -60,7 +60,7 @@ export default function NavLogo({
             href="/"
             aria-label="Home"
             onClick={scrollToTop}
-            className={className}
+            className={cn('focus-ring rounded-sm', className)}
         >
             {collapsible ? (
                 // The wordmark (viewBox 588.6 x 82.601) is ~8.91rem wide at h-5;

--- a/src/components/layout/Navbar/StudioMenu.tsx
+++ b/src/components/layout/Navbar/StudioMenu.tsx
@@ -43,7 +43,7 @@ export default function StudioMenu({ items, isActive }: StudioMenuProps) {
                 aria-haspopup="menu"
                 aria-expanded={open}
                 className={cn(
-                    'flex cursor-pointer items-center gap-1 rounded-full py-1.5 pr-2 pl-3 text-sm transition-colors',
+                    'focus-ring flex cursor-pointer items-center gap-1 rounded-full py-1.5 pr-2 pl-3 text-sm transition-colors',
                     open || groupActive
                         ? 'bg-foreground/10 text-foreground font-semibold'
                         : 'text-foreground/70 hover:text-foreground'
@@ -92,7 +92,7 @@ export default function StudioMenu({ items, isActive }: StudioMenuProps) {
                                     }
                                     onClick={close}
                                     className={cn(
-                                        'block rounded-xl px-4 py-2.5 text-sm transition-colors',
+                                        'focus-ring flex min-h-11 items-center rounded-xl px-4 text-sm transition-colors',
                                         isActive(item)
                                             ? 'bg-foreground/10 text-foreground font-semibold'
                                             : 'text-foreground/70 hover:text-foreground hover:bg-foreground/5'

--- a/src/components/layout/ThemeToggle/ThemeMenu.tsx
+++ b/src/components/layout/ThemeToggle/ThemeMenu.tsx
@@ -45,7 +45,7 @@ export default function ThemeMenu({ visible }: { visible: boolean }) {
                 aria-expanded={open}
                 aria-label="Theme"
                 title="Theme"
-                className="border-foreground/10 bg-background/60 text-foreground/80 hover:text-foreground relative flex size-11 cursor-pointer items-center justify-center rounded-full border shadow-lg shadow-black/5 backdrop-blur-lg transition-colors"
+                className="focus-ring border-foreground/10 bg-background/60 text-foreground/80 hover:text-foreground relative flex size-11 cursor-pointer items-center justify-center rounded-full border shadow-lg shadow-black/5 backdrop-blur-lg transition-colors"
             >
                 <ActiveIcon
                     aria-hidden="true"
@@ -85,7 +85,7 @@ export default function ThemeMenu({ visible }: { visible: boolean }) {
                                             close();
                                         }}
                                         className={cn(
-                                            'flex w-full cursor-pointer items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-colors',
+                                            'focus-ring flex min-h-11 w-full cursor-pointer items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-colors',
                                             active
                                                 ? 'bg-foreground/10 text-foreground font-semibold'
                                                 : 'text-foreground/70 hover:text-foreground hover:bg-foreground/5'

--- a/src/components/layout/ThemeToggle/index.tsx
+++ b/src/components/layout/ThemeToggle/index.tsx
@@ -29,10 +29,10 @@ export default function ThemeToggle({ className }: { className?: string }) {
                         aria-label={`${label} theme`}
                         title={`${label} theme`}
                         className={cn(
-                            'flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors',
+                            'focus-ring flex size-11 cursor-pointer items-center justify-center rounded-full transition-colors',
                             active
                                 ? 'bg-foreground/10 text-foreground'
-                                : 'text-foreground/60 hover:text-foreground'
+                                : 'text-foreground/70 hover:text-foreground'
                         )}
                     >
                         <Icon

--- a/src/components/pages/article-editor/ArticleEditor/EditorPreview.tsx
+++ b/src/components/pages/article-editor/ArticleEditor/EditorPreview.tsx
@@ -24,7 +24,7 @@ export default function EditorPreview({ body }: { body: string }) {
                 </span>
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8">
-                <div className="bg-foreground/5 text-foreground/60 mt-5 rounded-lg px-3 py-2 text-xs">
+                <div className="bg-foreground/5 text-foreground/70 mt-5 rounded-lg px-3 py-2 text-xs">
                     Live render of the body through the production Markdown,
                     Shiki, gist, Mermaid, and article component pipeline.
                 </div>

--- a/src/components/pages/article-editor/ArticleEditor/WritingGuide/GuideEntry.tsx
+++ b/src/components/pages/article-editor/ArticleEditor/WritingGuide/GuideEntry.tsx
@@ -27,7 +27,7 @@ export default function GuideEntry({
             <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
                 <p className="font-mono text-sm font-semibold">{entry.label}</p>
             </div>
-            <p className="text-foreground/60 mt-1 text-xs leading-relaxed">
+            <p className="text-foreground/70 mt-1 text-xs leading-relaxed">
                 {entry.note}
             </p>
             <pre className="border-foreground/10 bg-foreground/[0.03] mt-3 overflow-x-auto rounded-lg border p-3 font-mono text-[12px] leading-5">

--- a/src/components/pages/article-editor/ArticleEditor/WritingGuide/index.tsx
+++ b/src/components/pages/article-editor/ArticleEditor/WritingGuide/index.tsx
@@ -47,7 +47,7 @@ export default function WritingGuide({
                         <h2 className="mt-1 text-xl font-semibold">
                             Article anatomy
                         </h2>
-                        <p className="text-foreground/60 mt-1 text-sm">
+                        <p className="text-foreground/70 mt-1 text-sm">
                             The frontmatter fields and body features an article can
                             use. Insert a body snippet at your cursor, or load the
                             full example.

--- a/src/components/pages/article-editor/ArticleEditor/index.tsx
+++ b/src/components/pages/article-editor/ArticleEditor/index.tsx
@@ -152,7 +152,10 @@ export default function ArticleEditor({
     }
 
     return (
-        <main className="mx-auto w-full max-w-[112rem] px-4 py-24 sm:px-6 lg:px-8">
+        <main
+            id="main"
+            className="mx-auto w-full max-w-[112rem] px-4 py-24 sm:px-6 lg:px-8"
+        >
             <header className="mb-8">
                 <div className="flex flex-wrap items-center gap-3">
                     <p className="text-foreground/50 text-sm font-semibold tracking-[0.2em] uppercase">

--- a/src/components/pages/articles/ArticleCard/index.tsx
+++ b/src/components/pages/articles/ArticleCard/index.tsx
@@ -47,7 +47,7 @@ export default function ArticleCard({
                 >
                     <p
                         className={cn(
-                            'text-foreground/60',
+                            'text-foreground/70 tabular-nums',
                             compact ? 'text-xs' : 'text-sm'
                         )}
                     >

--- a/src/components/pages/articles/ArticleContent/index.tsx
+++ b/src/components/pages/articles/ArticleContent/index.tsx
@@ -12,7 +12,10 @@ export default function ArticleContent({ html }: { html: string }) {
         <div
             className={cn(
                 jetBrainsMono.variable,
-                'prose prose-lg dark:prose-invert mt-10 max-w-none',
+                // Cap the reading measure at ~75ch so body lines stay in the
+                // 65-75ch readability range on wide (xl/2xl) screens instead of
+                // stretching to the full content column.
+                'prose prose-lg dark:prose-invert mt-10 max-w-[75ch]',
                 styles.content
             )}
             dangerouslySetInnerHTML={{ __html: html }}

--- a/src/components/pages/articles/ArticleMeta.tsx
+++ b/src/components/pages/articles/ArticleMeta.tsx
@@ -21,7 +21,7 @@ export default function ArticleMeta({
     const wasUpdated = updated && updated !== date ? updated : null;
 
     return (
-        <div className="text-foreground/60 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+        <div className="text-foreground/70 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm tabular-nums">
             {difficulty && <DifficultyBadge level={difficulty} />}
             {date && <time dateTime={date}>{formatDate(date)}</time>}
             <span aria-hidden>·</span>

--- a/src/components/pages/articles/ArticlePager.tsx
+++ b/src/components/pages/articles/ArticlePager.tsx
@@ -19,7 +19,7 @@ function PagerLink({ article, direction, alignEnd = false }: PagerLinkProps) {
             href={`/articles/${article.slug}`}
             rel={isNext ? 'next' : 'prev'}
             className={cn(
-                'border-foreground/10 hover:border-foreground/30 hover:bg-foreground/[0.02] group flex flex-col gap-2 rounded-xl border p-5 transition-colors',
+                'focus-ring border-foreground/10 hover:border-foreground/30 hover:bg-foreground/[0.02] group flex flex-col gap-2 rounded-xl border p-5 transition-colors',
                 alignEnd ? 'sm:col-start-2 sm:items-end sm:text-right' : ''
             )}
         >

--- a/src/components/pages/articles/ArticleSearch/SearchModal.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useId, useRef } from 'react';
+import { useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import Search from '@/components/icons/search';
 import Close from '@/components/icons/close';
 import SearchSuggestions from '@/components/pages/articles/ArticleSearch/SearchSuggestions';
+import { useModalChrome } from '@/components/pages/articles/hooks/useModalChrome';
 import { useArticleSearchBox } from '@/components/pages/articles/ArticleSearch/hooks/useArticleSearchBox';
 import styles from '@/components/pages/articles/ArticleSearch/SearchModal.module.css';
 import { cn } from '@/utils/cn';
@@ -31,31 +32,19 @@ export default function SearchModal({
 }) {
     const box = useArticleSearchBox({ articles, initialQuery, onClose });
     const inputRef = useRef<HTMLInputElement>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
     const listboxId = useId();
     const optionId = (index: number) => `${listboxId}-option-${index}`;
     const activeDescendant =
         box.activeIndex >= 0 ? optionId(box.activeIndex) : undefined;
 
-    useEffect(() => {
-        const previouslyFocused = document.activeElement as HTMLElement | null;
-        const previousOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-        inputRef.current?.focus();
-
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') onClose();
-        };
-        document.addEventListener('keydown', onKeyDown);
-
-        return () => {
-            document.removeEventListener('keydown', onKeyDown);
-            document.body.style.overflow = previousOverflow;
-            previouslyFocused?.focus?.();
-        };
-    }, [onClose]);
+    // Body scroll lock, focus into the input, Escape to close, focus restore, and
+    // Tab focus trapping are shared with the article overlays via the modal hook.
+    useModalChrome(onClose, inputRef, dialogRef);
 
     return createPortal(
         <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label="Search articles"
@@ -84,7 +73,7 @@ export default function SearchModal({
                         role="combobox"
                         aria-label="Search articles"
                         aria-expanded={box.hasQuery}
-                        aria-controls={listboxId}
+                        aria-controls={box.hasQuery ? listboxId : undefined}
                         aria-autocomplete="list"
                         aria-activedescendant={activeDescendant}
                         value={box.query}
@@ -98,7 +87,7 @@ export default function SearchModal({
                             type="button"
                             onClick={box.clear}
                             aria-label="Clear search"
-                            className="text-foreground/55 hover:text-foreground hover:bg-foreground/10 grid size-7 shrink-0 place-items-center rounded-full transition-colors"
+                            className="focus-ring text-foreground/55 hover:text-foreground hover:bg-foreground/10 grid size-10 shrink-0 place-items-center rounded-full transition-colors"
                         >
                             <Close className="size-4" />
                         </button>
@@ -125,7 +114,10 @@ export default function SearchModal({
                             onSearchAll={box.goToResults}
                         />
                         <div className="border-foreground/10 text-foreground/70 flex items-center justify-between gap-3 border-t px-4 py-2.5 text-xs">
-                            <span>
+                            <span
+                                role="status"
+                                aria-live="polite"
+                            >
                                 <span className="text-foreground font-medium">
                                     {box.resultCount}
                                 </span>{' '}

--- a/src/components/pages/articles/ArticleSearch/SearchSuggestionItem.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchSuggestionItem.tsx
@@ -51,7 +51,7 @@ export default function SearchSuggestionItem({
                     />
                 </span>
                 <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="text-foreground/60 text-xs">
+                    <span className="text-foreground/70 text-xs tabular-nums">
                         {formatDate(article.date)}
                     </span>
                     {article.tags.map((tag) => (

--- a/src/components/pages/articles/ArticleSearch/SearchSuggestions.tsx
+++ b/src/components/pages/articles/ArticleSearch/SearchSuggestions.tsx
@@ -46,7 +46,7 @@ export default function SearchSuggestions({
             {suggestions.length === 0 && (
                 <li
                     role="presentation"
-                    className="text-foreground/60 px-3 py-2 text-sm"
+                    className="text-foreground/70 px-3 py-2 text-sm"
                 >
                     No titles or tags match. Try the full search below.
                 </li>

--- a/src/components/pages/articles/ArticleView/index.tsx
+++ b/src/components/pages/articles/ArticleView/index.tsx
@@ -48,6 +48,7 @@ export default function ArticleView({
 }) {
     return (
         <main
+            id="main"
             className={cn(
                 jetBrainsMono.variable,
                 'container mx-auto px-4 py-20 sm:py-28'

--- a/src/components/pages/articles/ArticlesIndex.tsx
+++ b/src/components/pages/articles/ArticlesIndex.tsx
@@ -22,7 +22,10 @@ export default function ArticlesIndex({
     );
 
     return (
-        <main className="container mx-auto px-4 py-20 sm:py-28">
+        <main
+            id="main"
+            className="container mx-auto px-4 py-20 sm:py-28"
+        >
             <Breadcrumb />
             <div className="flex items-start justify-between gap-4">
                 <SectionHeading as="h1">Articles</SectionHeading>

--- a/src/components/pages/articles/ArticlesSearch.tsx
+++ b/src/components/pages/articles/ArticlesSearch.tsx
@@ -15,7 +15,10 @@ export default function ArticlesSearch({
     articles: ArticleSummary[];
 }) {
     return (
-        <main className="container mx-auto px-4 py-20 sm:py-28">
+        <main
+            id="main"
+            className="container mx-auto px-4 py-20 sm:py-28"
+        >
             <Breadcrumb />
             <SectionHeading as="h1">Search articles</SectionHeading>
             <p className="text-foreground/70 mt-6 max-w-3xl text-lg leading-relaxed">

--- a/src/components/pages/articles/CodeBlock/CodeCopyButton.tsx
+++ b/src/components/pages/articles/CodeBlock/CodeCopyButton.tsx
@@ -12,7 +12,7 @@ export default function CodeCopyButton({ code }: { code: string }) {
             type="button"
             aria-label={copied ? 'Copied' : 'Copy code'}
             onClick={() => copy(code)}
-            className="text-foreground/70 hover:bg-foreground/10 hover:text-foreground focus-visible:bg-foreground/10 focus-visible:text-foreground inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors"
+            className="focus-ring text-foreground/70 hover:bg-foreground/10 hover:text-foreground inline-flex min-h-9 cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors"
         >
             {copied ? (
                 <>

--- a/src/components/pages/articles/Comments/index.tsx
+++ b/src/components/pages/articles/Comments/index.tsx
@@ -31,7 +31,12 @@ export default function Comments() {
             aria-label="Comments"
             className={cn('border-foreground/10 mt-16 border-t pt-10')}
         >
-            <div ref={containerRef} />
+            {/* Reserve height so the lazy giscus iframe does not collapse then
+                expand (CLS) when it injects at the foot of the article. */}
+            <div
+                ref={containerRef}
+                className="min-h-60"
+            />
         </section>
     );
 }

--- a/src/components/pages/articles/ImageLightbox/LightboxOverlay.tsx
+++ b/src/components/pages/articles/ImageLightbox/LightboxOverlay.tsx
@@ -20,7 +20,7 @@ function OverlayButton({
         <button
             type={type ?? 'button'}
             className={cn(
-                'flex size-10 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur transition-colors hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-none',
+                'flex size-11 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur transition-colors hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-none',
                 className
             )}
             {...rest}
@@ -48,6 +48,7 @@ export default function LightboxOverlay({
     onClose: () => void;
 }) {
     const closeRef = useRef<HTMLButtonElement>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
     const hasMultiple = images.length > 1;
 
     const goTo = useCallback(
@@ -60,7 +61,7 @@ export default function LightboxOverlay({
 
     // Scroll lock, focus management, and Escape live in the shared modal hook,
     // mounted once; only the left/right paging re-binds as the index changes.
-    useModalChrome(onClose, closeRef);
+    useModalChrome(onClose, closeRef, dialogRef);
 
     useEffect(() => {
         if (!hasMultiple) return;
@@ -76,6 +77,7 @@ export default function LightboxOverlay({
 
     return createPortal(
         <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label="Image viewer"

--- a/src/components/pages/articles/MermaidRenderer/MermaidIconButton.tsx
+++ b/src/components/pages/articles/MermaidRenderer/MermaidIconButton.tsx
@@ -14,7 +14,7 @@ export default function MermaidIconButton({
         <button
             type={type ?? 'button'}
             className={cn(
-                'border-foreground/10 bg-background/80 text-foreground/70 hover:bg-foreground/10 hover:text-foreground focus-visible:bg-foreground/10 focus-visible:text-foreground grid size-8 cursor-pointer place-items-center rounded-md border shadow-sm backdrop-blur transition-colors',
+                'focus-ring border-foreground/10 bg-background/80 text-foreground/70 hover:bg-foreground/10 hover:text-foreground grid size-10 cursor-pointer place-items-center rounded-md border shadow-sm backdrop-blur transition-colors',
                 className
             )}
             {...rest}

--- a/src/components/pages/articles/MermaidRenderer/MermaidModal.tsx
+++ b/src/components/pages/articles/MermaidRenderer/MermaidModal.tsx
@@ -21,11 +21,13 @@ interface MermaidModalProps {
  */
 export default function MermaidModal({ svg, source, onClose }: MermaidModalProps) {
     const closeRef = useRef<HTMLButtonElement>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
 
-    useModalChrome(onClose, closeRef);
+    useModalChrome(onClose, closeRef, dialogRef);
 
     return createPortal(
         <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label="Diagram, full view"

--- a/src/components/pages/articles/Pagination.tsx
+++ b/src/components/pages/articles/Pagination.tsx
@@ -28,7 +28,7 @@ interface PaginationProps {
 }
 
 const itemBase =
-    'inline-flex h-9 min-w-9 items-center justify-center rounded-full border px-3 text-sm transition-colors';
+    'focus-ring inline-flex h-11 min-w-11 items-center justify-center rounded-full border px-3 text-sm transition-colors';
 const itemInactive =
     'border-foreground/15 text-foreground/70 hover:text-foreground hover:bg-foreground/5';
 

--- a/src/components/pages/articles/SearchResults.tsx
+++ b/src/components/pages/articles/SearchResults.tsx
@@ -62,7 +62,7 @@ export default function SearchResults({
             </div>
 
             {query.length === 0 ? (
-                <p className="text-foreground/60 mt-12 text-base">
+                <p className="text-foreground/70 mt-12 text-base">
                     Open search to find an article by its title or a tag.
                 </p>
             ) : results.length > 0 ? (
@@ -75,7 +75,7 @@ export default function SearchResults({
                     />
                 </>
             ) : (
-                <p className="text-foreground/60 mt-12 text-base">
+                <p className="text-foreground/70 mt-12 text-base">
                     Nothing matched. Try a different title or tag.
                 </p>
             )}

--- a/src/components/pages/articles/SeriesNav.tsx
+++ b/src/components/pages/articles/SeriesNav.tsx
@@ -35,7 +35,7 @@ export default function SeriesNav({
             )}
         >
             <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                <p className="text-foreground/60 text-xs font-semibold tracking-[0.12em] uppercase">
+                <p className="text-foreground/70 text-xs font-semibold tracking-[0.12em] uppercase">
                     Part {position} of {series.parts.length}
                 </p>
                 <p className="text-foreground/70 text-xs">Series</p>

--- a/src/components/pages/articles/TableOfContents/MobileTableOfContents.tsx
+++ b/src/components/pages/articles/TableOfContents/MobileTableOfContents.tsx
@@ -32,7 +32,7 @@ export default function MobileTableOfContents({
             className="border-foreground/10 bg-foreground/[0.02] group mb-8 rounded-xl border lg:hidden"
         >
             <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold [&::-webkit-details-marker]:hidden">
-                <span className="text-foreground/60 text-xs tracking-[0.12em] uppercase">
+                <span className="text-foreground/70 text-xs tracking-[0.12em] uppercase">
                     On this page
                 </span>
                 <ChevronIcon className="text-foreground/70 size-4 transition-transform group-open:rotate-180" />

--- a/src/components/pages/articles/TableOfContents/TocList.tsx
+++ b/src/components/pages/articles/TableOfContents/TocList.tsx
@@ -27,10 +27,10 @@ export default function TocList({
                             onClick={onNavigate}
                             aria-current={isActive ? 'location' : undefined}
                             className={cn(
-                                'group flex items-center gap-2 rounded-md py-1 leading-snug transition-colors',
+                                'focus-ring group flex items-center gap-2 rounded-md py-1 leading-snug transition-colors',
                                 item.level === 3 ? 'pl-5' : 'pl-2',
                                 isActive
-                                    ? 'text-[var(--accent-to)]'
+                                    ? 'font-medium text-[color-mix(in_oklab,var(--accent-to),var(--foreground)_45%)]'
                                     : 'text-foreground/70 hover:text-foreground'
                             )}
                         >

--- a/src/components/pages/articles/TableOfContents/index.tsx
+++ b/src/components/pages/articles/TableOfContents/index.tsx
@@ -33,7 +33,7 @@ export default function TableOfContents({
             style={accentStyle(accentColors)}
             className="sticky top-24 hidden max-h-[calc(100vh-8rem)] overflow-y-auto lg:block"
         >
-            <p className="text-foreground/60 mb-3 text-xs font-semibold tracking-[0.12em] uppercase">
+            <p className="text-foreground/70 mb-3 text-xs font-semibold tracking-[0.12em] uppercase">
                 On this page
             </p>
             <TocList

--- a/src/components/pages/articles/TagFilter.tsx
+++ b/src/components/pages/articles/TagFilter.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { cn } from '@/utils/cn';
 
 const base =
-    'inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition-colors';
+    'focus-ring inline-flex min-h-11 items-center rounded-full border px-4 text-sm transition-colors';
 const inactive =
     'border-foreground/15 text-foreground/70 hover:border-foreground/50 hover:text-foreground';
 const activeClasses = 'border-foreground bg-foreground text-background';

--- a/src/components/pages/articles/TagLink.tsx
+++ b/src/components/pages/articles/TagLink.tsx
@@ -14,7 +14,7 @@ export default function TagLink({
             <Link
                 href={`/articles?tag=${encodeURIComponent(tag)}`}
                 className={cn(
-                    'border-foreground/15 text-foreground/70 hover:border-foreground/50 hover:text-foreground inline-block rounded-full border transition-colors',
+                    'focus-ring border-foreground/15 text-foreground/70 hover:border-foreground/50 hover:text-foreground inline-block rounded-full border transition-colors',
                     className
                 )}
             >

--- a/src/components/pages/articles/TechStack.tsx
+++ b/src/components/pages/articles/TechStack.tsx
@@ -17,7 +17,7 @@ export default function TechStack({
 
     return (
         <div className={cn('flex flex-wrap items-center gap-2', className)}>
-            <span className="text-foreground/60 text-xs font-semibold tracking-[0.1em] uppercase">
+            <span className="text-foreground/70 text-xs font-semibold tracking-[0.1em] uppercase">
                 Stack
             </span>
             <ul className="flex flex-wrap gap-2">

--- a/src/components/pages/articles/WhatYoullLearn.tsx
+++ b/src/components/pages/articles/WhatYoullLearn.tsx
@@ -34,7 +34,7 @@ export default function WhatYoullLearn({
             />
             <h2
                 id="what-youll-learn"
-                className="text-foreground/60 text-xs font-semibold tracking-[0.12em] uppercase"
+                className="text-foreground/70 text-xs font-semibold tracking-[0.12em] uppercase"
             >
                 What you&rsquo;ll learn
             </h2>

--- a/src/components/pages/articles/hooks/useModalChrome.ts
+++ b/src/components/pages/articles/hooks/useModalChrome.ts
@@ -2,17 +2,29 @@
 
 import { useEffect, useRef, type RefObject } from 'react';
 
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
 /**
  * The shared chrome behind the article overlays (Mermaid full view, image
- * lightbox): on mount it locks body scroll, moves focus to `initialFocusRef`,
- * and closes on Escape; on unmount it restores scroll and returns focus to
- * whatever was focused before. The effect runs once for the overlay's lifetime,
- * `onClose` is read through a ref so a fresh callback identity each render never
- * re-captures the previously focused element (which would break focus return).
+ * lightbox, article search): on mount it locks body scroll, moves focus to
+ * `initialFocusRef`, closes on Escape, and (when `containerRef` is given) traps
+ * Tab focus inside the dialog so keyboard users cannot reach the page behind the
+ * scrim; on unmount it restores scroll and returns focus to whatever was focused
+ * before. The effect runs once for the overlay's lifetime, `onClose` is read
+ * through a ref so a fresh callback identity each render never re-captures the
+ * previously focused element (which would break focus return).
  */
 export function useModalChrome<T extends HTMLElement>(
     onClose: () => void,
-    initialFocusRef?: RefObject<T | null>
+    initialFocusRef?: RefObject<T | null>,
+    containerRef?: RefObject<HTMLElement | null>
 ): void {
     const onCloseRef = useRef(onClose);
     onCloseRef.current = onClose;
@@ -24,7 +36,33 @@ export function useModalChrome<T extends HTMLElement>(
         initialFocusRef?.current?.focus();
 
         const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') onCloseRef.current();
+            if (event.key === 'Escape') {
+                onCloseRef.current();
+                return;
+            }
+            if (event.key !== 'Tab' || !containerRef?.current) return;
+
+            const focusables = Array.from(
+                containerRef.current.querySelectorAll<HTMLElement>(
+                    FOCUSABLE_SELECTOR
+                )
+            ).filter((element) => element.offsetParent !== null);
+            if (focusables.length === 0) return;
+
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            const active = document.activeElement;
+
+            if (!containerRef.current.contains(active as Node)) {
+                event.preventDefault();
+                first.focus();
+            } else if (event.shiftKey && active === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && active === last) {
+                event.preventDefault();
+                first.focus();
+            }
         };
         document.addEventListener('keydown', onKeyDown);
 
@@ -33,5 +71,5 @@ export function useModalChrome<T extends HTMLElement>(
             document.body.style.overflow = previousOverflow;
             previouslyFocused?.focus?.();
         };
-    }, [initialFocusRef]);
+    }, [initialFocusRef, containerRef]);
 }

--- a/src/components/pages/common/TagGroup.tsx
+++ b/src/components/pages/common/TagGroup.tsx
@@ -14,7 +14,7 @@ export default function TagGroup({ label, tags }: TagGroupProps) {
     return (
         <div>
             {label && (
-                <h3 className="text-foreground/60 text-base font-bold">
+                <h3 className="text-foreground/70 text-base font-bold">
                     {label}
                 </h3>
             )}

--- a/src/components/pages/home/AboutMeArea/FacetCard.tsx
+++ b/src/components/pages/home/AboutMeArea/FacetCard.tsx
@@ -45,7 +45,7 @@ export default function FacetCard({
                     />
                     <h3 className="font-semibold">{facet.title}</h3>
                 </div>
-                <p className="text-foreground/60 mt-2 text-sm leading-relaxed">
+                <p className="text-foreground/70 mt-2 text-sm leading-relaxed">
                     {facet.text}
                 </p>
             </div>

--- a/src/components/pages/home/AboutMeArea/index.tsx
+++ b/src/components/pages/home/AboutMeArea/index.tsx
@@ -11,7 +11,7 @@ export default function AboutMeArea() {
             <div className="container mx-auto flex min-h-svh flex-col justify-center gap-12 px-4 py-20 sm:py-28">
                 <div className="space-y-3 text-center">
                     <SectionHeading>About me</SectionHeading>
-                    <p className="text-foreground/60 mx-auto max-w-xl">
+                    <p className="text-foreground/70 mx-auto max-w-xl">
                         The mindset, experience, and curiosity behind the
                         software I build.
                     </p>

--- a/src/components/pages/home/ContactArea/ContactAside.tsx
+++ b/src/components/pages/home/ContactArea/ContactAside.tsx
@@ -18,7 +18,7 @@ export default function ContactAside() {
     return (
         <div className="flex flex-col gap-6 text-left">
             <div className="flex flex-col gap-3">
-                <span className="text-foreground/60 text-xs font-semibold tracking-[0.22em] uppercase">
+                <span className="text-foreground/70 text-xs font-semibold tracking-[0.22em] uppercase">
                     {asideEyebrow}
                 </span>
                 <SectionHeading

--- a/src/components/pages/home/ContactArea/ContactForm.tsx
+++ b/src/components/pages/home/ContactArea/ContactForm.tsx
@@ -96,7 +96,7 @@ export default function ContactForm() {
 
                                 {status === 'error' && errorMessage && (
                                     <p
-                                        role="status"
+                                        role="alert"
                                         className="text-sm text-red-600 dark:text-red-400"
                                     >
                                         {errorMessage}

--- a/src/components/pages/home/ContactArea/StatusDot.tsx
+++ b/src/components/pages/home/ContactArea/StatusDot.tsx
@@ -4,7 +4,7 @@
  */
 export default function StatusDot({ label }: { label: string }) {
     return (
-        <span className="text-foreground/60 inline-flex items-center gap-2.5 text-sm">
+        <span className="text-foreground/70 inline-flex items-center gap-2.5 text-sm">
             <span className="relative flex size-2.5">
                 <span className="absolute inline-flex size-full rounded-full bg-emerald-500/70 motion-safe:animate-ping" />
                 <span className="relative inline-flex size-2.5 rounded-full bg-emerald-500" />

--- a/src/components/pages/home/HeroArea/ScrollDownCue.tsx
+++ b/src/components/pages/home/HeroArea/ScrollDownCue.tsx
@@ -19,7 +19,7 @@ export default function ScrollDownCue() {
             href="#about"
             aria-label="Scroll to the about section"
             className={cn(
-                'text-foreground/55 hover:text-foreground/70 mb-6 transition-all duration-500 ease-out motion-reduce:transition-none motion-safe:animate-bounce sm:mb-10',
+                'focus-ring text-foreground/55 hover:text-foreground/70 mb-6 inline-flex min-h-11 min-w-11 items-center justify-center rounded-full transition-all duration-500 ease-out motion-reduce:transition-none motion-safe:animate-bounce sm:mb-10',
                 navbarVisible
                     ? 'pointer-events-none invisible opacity-0'
                     : 'visible opacity-100'

--- a/src/components/pages/home/HeroArea/SocialIcons.tsx
+++ b/src/components/pages/home/HeroArea/SocialIcons.tsx
@@ -13,7 +13,7 @@ export default function SocialIcons() {
                     title={name}
                     aria-label={name}
                     className={cn(
-                        'p-2 transition-[color,transform] duration-300 motion-safe:hover:scale-110',
+                        'focus-ring inline-flex min-h-11 min-w-11 items-center justify-center rounded-full transition-[color,transform] duration-300 motion-safe:hover:scale-110',
                         socialColorClassNames
                     )}
                 >

--- a/src/components/pages/home/ProjectsArea/ProjectCard/index.tsx
+++ b/src/components/pages/home/ProjectsArea/ProjectCard/index.tsx
@@ -34,12 +34,12 @@ export default function ProjectCard({
                 'border-foreground/10 hover:border-foreground/30 relative isolate flex flex-col rounded-2xl border p-6 transition-all duration-300 hover:shadow-lg sm:p-8'
             )}
         >
-            <p className="text-foreground/60 text-xs font-bold tracking-wide uppercase">
+            <p className="text-foreground/70 text-xs font-bold tracking-wide uppercase">
                 {project.category}
             </p>
-            <h3 className="mt-2 text-lg font-bold sm:text-xl">
+            <h4 className="mt-2 text-lg font-bold sm:text-xl">
                 {project.name}
-            </h3>
+            </h4>
             <p className="text-foreground/70 mt-3 grow text-base leading-relaxed">
                 {project.description}
             </p>

--- a/src/components/pages/home/ProjectsArea/ProjectLink.tsx
+++ b/src/components/pages/home/ProjectsArea/ProjectLink.tsx
@@ -17,7 +17,7 @@ export default function ProjectLink({
             target="_blank"
             rel="noopener noreferrer"
             aria-label={ariaLabel}
-            className="hover:text-foreground/60 inline-flex items-center gap-2 transition-colors"
+            className="focus-ring hover:text-foreground/60 inline-flex min-h-11 items-center gap-2 rounded-sm transition-colors"
         >
             <Icon
                 className="size-5"

--- a/src/components/pages/home/ProjectsArea/ResumeBridge.tsx
+++ b/src/components/pages/home/ProjectsArea/ResumeBridge.tsx
@@ -9,7 +9,7 @@ import ChevronIcon from '@/components/icons/chevron';
 export default function ResumeBridge() {
     return (
         <div className="mt-14 text-center">
-            <p className="text-foreground/60">
+            <p className="text-foreground/70">
                 My professional, client-facing work lives on the resume.
             </p>
             <Link

--- a/src/components/pages/home/ProjectsArea/index.tsx
+++ b/src/components/pages/home/ProjectsArea/index.tsx
@@ -15,20 +15,20 @@ export default function ProjectsArea() {
             <div className="container mx-auto px-4">
                 <div className="space-y-3 text-center">
                     <SectionHeading>Open Source</SectionHeading>
-                    <p className="text-foreground/60 mx-auto max-w-xl">
+                    <p className="text-foreground/70 mx-auto max-w-xl">
                         Tools, plugins, and experiments I build in the open.
                     </p>
                 </div>
 
                 <div className="mt-12 space-y-6">
-                    <h3 className="text-foreground/60 text-center text-sm font-bold tracking-wider uppercase">
+                    <h3 className="text-foreground/70 text-center text-sm font-bold tracking-wider uppercase">
                         Packages &amp; Plugins
                     </h3>
                     <ProjectGrid projects={packageProjects} />
                 </div>
 
                 <div className="mt-12 space-y-6">
-                    <h3 className="text-foreground/60 text-center text-sm font-bold tracking-wider uppercase">
+                    <h3 className="text-foreground/70 text-center text-sm font-bold tracking-wider uppercase">
                         Personal Projects
                     </h3>
                     <ProjectGrid

--- a/src/components/pages/home/SkillsArea/SkillCard/index.tsx
+++ b/src/components/pages/home/SkillsArea/SkillCard/index.tsx
@@ -29,7 +29,7 @@ export default function SkillCard({ skill }: { skill: Skill }) {
         >
             <Icon
                 className={cn(
-                    'text-foreground/60 size-7 shrink-0 transition-colors duration-300',
+                    'text-foreground/70 size-7 shrink-0 transition-colors duration-300',
                     color
                         ? 'group-hover:[color:var(--brand-color)]'
                         : 'group-hover:text-foreground'

--- a/src/components/pages/network-status/NetworkStatusStage/index.tsx
+++ b/src/components/pages/network-status/NetworkStatusStage/index.tsx
@@ -26,6 +26,7 @@ import styles from '@/components/pages/network-status/NetworkStatusStage/Network
 export default function NetworkStatusStage() {
     return (
         <main
+            id="main"
             data-network-root
             data-status="offline"
             // The reconnect script may flip data-status (and the text below) to the
@@ -44,7 +45,11 @@ export default function NetworkStatusStage() {
 
             <SignalRings />
 
-            <span className="border-foreground/10 bg-background/60 text-foreground/70 mt-8 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium backdrop-blur-sm">
+            <span
+                role="status"
+                aria-live="polite"
+                className="border-foreground/10 bg-background/60 text-foreground/70 mt-8 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium backdrop-blur-sm"
+            >
                 <span
                     aria-hidden="true"
                     className={cn(styles.dot, 'size-2 rounded-full')}
@@ -80,7 +85,7 @@ export default function NetworkStatusStage() {
                     label={AUTO_RELOAD_LABEL}
                     data-network-autoreload
                     className="accent-[var(--network-accent)]"
-                    labelClassName="text-foreground/60 hover:text-foreground/80 transition-colors"
+                    labelClassName="text-foreground/70 hover:text-foreground/80 transition-colors"
                 />
                 <span
                     data-network-countdown

--- a/src/components/pages/now/NowCard/NowCard.module.css
+++ b/src/components/pages/now/NowCard/NowCard.module.css
@@ -39,12 +39,12 @@
     @apply opacity-100;
 }
 
-/* Emoji badge: a rounded square carrying a soft tint and ring of the card's
+/* Icon badge: a rounded square carrying a soft tint and ring of the card's
    accent so the badge, glow, and card read as one accented unit. The accent
    mix strength steps up in dark mode to keep the tint legible on the dark
    surface. */
 .badge {
-    @apply grid size-11 shrink-0 place-items-center rounded-xl border text-xl;
+    @apply grid size-11 shrink-0 place-items-center rounded-xl border;
     background-color: color-mix(
         in oklab,
         var(--card-accent, var(--foreground)) 10%,

--- a/src/components/pages/now/NowCard/index.tsx
+++ b/src/components/pages/now/NowCard/index.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/utils/cn';
 /**
  * A single /now section rendered as a snapshot card, the sibling of the /uses
  * catalog entry (UsesCard): a monospace index in the corner, an accent-tinted
- * emoji badge and title, an optional intro, the section's content blocks, then an
+ * icon badge and title, an optional intro, the section's content blocks, then an
  * optional closing outro. Each card is given its own accent hue derived from its
  * position with the golden angle, so consecutive cards land far apart on the
  * colour wheel and any section added to contents.ts gets a distinct accent
@@ -45,11 +45,11 @@ export default function NowCard({
             </span>
 
             <div className="flex items-center gap-3.5 pr-8">
-                <span
-                    aria-hidden="true"
-                    className={styles.badge}
-                >
-                    {section.emoji}
+                <span className={styles.badge}>
+                    <section.Icon
+                        aria-hidden="true"
+                        className="text-foreground/80 size-5"
+                    />
                 </span>
                 <h2 className="text-lg font-bold sm:text-xl">
                     {section.title}
@@ -72,7 +72,7 @@ export default function NowCard({
             </div>
 
             {section.outro && (
-                <p className="text-foreground/60 mt-6 text-sm leading-relaxed italic">
+                <p className="text-foreground/70 mt-6 text-sm leading-relaxed italic">
                     {section.outro}
                 </p>
             )}

--- a/src/components/pages/now/types.ts
+++ b/src/components/pages/now/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentType, SVGProps } from 'react';
+
 export type NowBlockData =
     | { kind: 'tags'; label?: string; tags: string[] }
     | { kind: 'list'; items: string[] }
@@ -5,7 +7,8 @@ export type NowBlockData =
 
 export type NowSectionData = {
     title: string;
-    emoji: string;
+    /** Section badge icon (an SVG icon component from `@/components/icons`). */
+    Icon: ComponentType<SVGProps<SVGSVGElement>>;
     intro?: string;
     outro?: string;
     /**

--- a/src/components/pages/resume/DownloadPdfButton.tsx
+++ b/src/components/pages/resume/DownloadPdfButton.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { cn } from '@/utils/cn';
+import Button from '@/components/ui/Button';
 
 /**
  * Opens the browser print dialog (Save as PDF). The print stylesheet on the
  * resume page restyles the document into a clean light single column, so the
- * saved PDF matches the on-page content minus the site chrome.
+ * saved PDF matches the on-page content minus the site chrome. Built on the
+ * shared Button so it inherits the site's 44px target, focus ring, and styling.
  */
 export default function DownloadPdfButton({
     className,
@@ -13,13 +14,10 @@ export default function DownloadPdfButton({
     className?: string;
 }) {
     return (
-        <button
-            type="button"
+        <Button
+            variant="outline"
             onClick={() => window.print()}
-            className={cn(
-                'border-foreground/15 text-foreground/80 hover:border-foreground/30 hover:text-foreground inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors',
-                className
-            )}
+            className={className}
         >
             <svg
                 aria-hidden="true"
@@ -36,6 +34,6 @@ export default function DownloadPdfButton({
                 <path d="M12 15V3" />
             </svg>
             Download PDF
-        </button>
+        </Button>
     );
 }

--- a/src/components/pages/resume/ExperienceItem.tsx
+++ b/src/components/pages/resume/ExperienceItem.tsx
@@ -36,7 +36,7 @@ export default function ExperienceItem({ entry }: { entry: ExperienceEntry }) {
                                 {position.role}
                                 {position.promotedFrom &&
                                     position.promotedFrom.length > 0 && (
-                                        <span className="text-foreground/60 font-normal">
+                                        <span className="text-foreground/70 font-normal">
                                             {' '}
                                             (promoted from{' '}
                                             <span className="print:hidden">

--- a/src/components/pages/resume/ProjectItem.tsx
+++ b/src/components/pages/resume/ProjectItem.tsx
@@ -26,7 +26,7 @@ export default function ProjectItem({ entry }: { entry: ProjectEntry }) {
                         >
                             {' · '}
                         </span>
-                        <span className="text-foreground/60 font-normal italic">
+                        <span className="text-foreground/70 font-normal italic">
                             {entry.tagline}
                         </span>
                     </>

--- a/src/components/pages/resume/ResumeContactHeader.tsx
+++ b/src/components/pages/resume/ResumeContactHeader.tsx
@@ -13,14 +13,14 @@ export default function ResumeContactHeader({
 }) {
     return (
         <header className="text-center">
-            <p className="text-xl font-bold tracking-tight sm:text-2xl print:text-[16pt]">
+            <h1 className="text-xl font-bold tracking-tight sm:text-2xl print:text-[16pt]">
                 {name}
-            </p>
+            </h1>
             <div className="mt-2 print:mt-1">
                 <ContactLine contacts={contacts} />
             </div>
             {location && (
-                <p className="text-foreground/60 mt-1 font-mono text-[11px] print:font-[Helvetica,Arial,sans-serif] print:text-[9pt]">
+                <p className="text-foreground/70 mt-1 font-mono text-[11px] print:font-[Helvetica,Arial,sans-serif] print:text-[9pt]">
                     {location}
                 </p>
             )}

--- a/src/components/pages/uses/SpecList.tsx
+++ b/src/components/pages/uses/SpecList.tsx
@@ -14,7 +14,7 @@ export default function SpecList({ label, specs }: SpecListProps) {
     return (
         <div>
             {label && (
-                <h3 className="text-foreground/60 mb-3 text-base font-bold">
+                <h3 className="text-foreground/70 mb-3 text-base font-bold">
                     {label}
                 </h3>
             )}

--- a/src/components/pages/uses/UsesCard/UsesCard.module.css
+++ b/src/components/pages/uses/UsesCard/UsesCard.module.css
@@ -38,12 +38,12 @@
     @apply opacity-100;
 }
 
-/* Emoji badge: a rounded square carrying a soft tint and ring of the card's
+/* Icon badge: a rounded square carrying a soft tint and ring of the card's
    accent so the badge, glow, and card read as one accented unit. The accent
    mix strength steps up in dark mode to keep the tint legible on the dark
    surface. */
 .badge {
-    @apply grid size-11 shrink-0 place-items-center rounded-xl border text-xl;
+    @apply grid size-11 shrink-0 place-items-center rounded-xl border;
     background-color: color-mix(
         in oklab,
         var(--card-accent, var(--foreground)) 10%,

--- a/src/components/pages/uses/UsesCard/index.tsx
+++ b/src/components/pages/uses/UsesCard/index.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/utils/cn';
 
 /**
  * A single /uses section rendered as a field-guide catalog entry: a monospace
- * index in the corner, an accent-tinted emoji badge and title, an optional intro,
+ * index in the corner, an accent-tinted icon badge and title, an optional intro,
  * then the section's content blocks. Each card is given its own accent hue derived
  * from its position with the golden angle, so consecutive cards land far apart on
  * the colour wheel and any section added to contents.ts gets a distinct accent
@@ -44,11 +44,11 @@ export default function UsesCard({
             </span>
 
             <div className="flex items-center gap-3.5 pr-8">
-                <span
-                    aria-hidden="true"
-                    className={styles.badge}
-                >
-                    {section.emoji}
+                <span className={styles.badge}>
+                    <section.Icon
+                        aria-hidden="true"
+                        className="text-foreground/80 size-5"
+                    />
                 </span>
                 <h2 className="text-lg font-bold sm:text-xl">
                     {section.title}

--- a/src/components/pages/uses/types.ts
+++ b/src/components/pages/uses/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentType, SVGProps } from 'react';
+
 export type UsesBlockData =
     | {
           kind: 'specs';
@@ -10,7 +12,8 @@ export type UsesBlockData =
 
 export type UsesSectionData = {
     title: string;
-    emoji: string;
+    /** Section badge icon (an SVG icon component from `@/components/icons`). */
+    Icon: ComponentType<SVGProps<SVGSVGElement>>;
     intro?: string;
     /**
      * Marks a content-heavy section as a feature card that spans two columns in

--- a/src/components/pwa/UpdateToast/index.tsx
+++ b/src/components/pwa/UpdateToast/index.tsx
@@ -36,7 +36,7 @@ export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
             <button
                 type="button"
                 onClick={onReload}
-                className="bg-foreground text-background hover:bg-foreground/90 ml-1 cursor-pointer rounded-lg px-3 py-1 text-xs font-semibold transition-colors"
+                className="focus-ring bg-foreground text-background hover:bg-foreground/90 ml-1 inline-flex min-h-9 cursor-pointer items-center rounded-lg px-3 text-xs font-semibold transition-colors"
             >
                 Reload
             </button>
@@ -44,7 +44,7 @@ export default function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
                 type="button"
                 onClick={onDismiss}
                 aria-label="Dismiss"
-                className="text-foreground/70 hover:bg-foreground/10 hover:text-foreground flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-lg leading-none transition-colors"
+                className="focus-ring text-foreground/70 hover:bg-foreground/10 hover:text-foreground flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-md text-lg leading-none transition-colors"
             >
                 &times;
             </button>

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -4,7 +4,7 @@ import Spinner from '@/components/ui/Spinner';
 export type ButtonVariant = 'primary' | 'outline';
 
 const buttonBaseClassName =
-    'inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:ring-foreground/50 focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none';
+    'focus-ring inline-flex min-h-11 cursor-pointer touch-manipulation items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors';
 
 const variantClassNames: Record<ButtonVariant, string> = {
     primary:
@@ -48,6 +48,7 @@ export default function Button({
         <button
             type={type}
             disabled={disabled || isLoading}
+            aria-busy={isLoading}
             className={buttonClassName(variant, className)}
             {...rest}
         >

--- a/src/components/ui/Checkbox/index.tsx
+++ b/src/components/ui/Checkbox/index.tsx
@@ -25,7 +25,10 @@ export default function Checkbox({
         >
             <input
                 type="checkbox"
-                className={cn('accent-foreground size-4 rounded', className)}
+                className={cn(
+                    'accent-foreground focus-ring size-4 rounded',
+                    className
+                )}
                 {...rest}
             />
             {label}

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -2,27 +2,84 @@ import { useId } from 'react';
 import { cn } from '@/utils/cn';
 
 export const fieldControlClassName =
-    'border-foreground/15 bg-background/60 focus:border-foreground/40 focus:ring-foreground/20 w-full rounded-xl border px-3.5 py-2.5 text-sm outline-none transition focus:ring-2';
+    'border-foreground/15 bg-background/60 focus:border-foreground/40 focus:ring-foreground/20 min-h-11 w-full rounded-xl border px-3.5 py-2.5 text-sm outline-none transition focus:ring-2 aria-[invalid=true]:border-red-500/60 aria-[invalid=true]:focus:ring-red-500/25';
+
+type FieldMessagesProps = {
+    describedById: string;
+    error?: string;
+    helperText?: string;
+};
+
+/**
+ * Shared helper/error region for the field primitives. The error takes over the
+ * `role="alert"` (assertive) announcement when present; otherwise persistent
+ * helper text is exposed as `role="status"` (polite). Both share the id the
+ * control points at via `aria-describedby`.
+ */
+export function FieldMessages({
+    describedById,
+    error,
+    helperText,
+}: FieldMessagesProps) {
+    if (error) {
+        return (
+            <p id={describedById} role="alert" className="text-xs text-red-600 dark:text-red-400">
+                {error}
+            </p>
+        );
+    }
+
+    if (helperText) {
+        return (
+            <p
+                id={describedById}
+                role="status"
+                className="text-foreground/70 text-xs"
+            >
+                {helperText}
+            </p>
+        );
+    }
+
+    return null;
+}
+
+/** Programmatic + visual required marker shared by the labeled field primitives. */
+export function RequiredMark() {
+    return (
+        <span className="text-red-600 dark:text-red-400">
+            <span aria-hidden="true"> *</span>
+            <span className="sr-only"> (required)</span>
+        </span>
+    );
+}
 
 type InputProps = React.ComponentPropsWithRef<'input'> & {
     label: string;
     labelClassName?: string;
+    error?: string;
+    helperText?: string;
 };
 
 /**
  * Labeled text input built on the shared field styling. Theme-aware via the
  * `foreground`/`background` tokens. Forwards `ref` (React 19 ref-as-prop) so a
- * form can focus it, e.g. after a reset.
+ * form can focus it, e.g. after a reset. When `error`/`helperText` is set, the
+ * message is wired to the control via `aria-describedby` and `aria-invalid`.
  */
 export default function Input({
     label,
     labelClassName,
+    error,
+    helperText,
     id,
     className,
     ...rest
 }: InputProps) {
     const generatedId = useId();
     const inputId = id ?? generatedId;
+    const describedById = `${inputId}-message`;
+    const hasMessage = Boolean(error || helperText);
 
     return (
         <div className="flex flex-col gap-2 text-left">
@@ -31,11 +88,19 @@ export default function Input({
                 className={cn('text-sm font-medium', labelClassName)}
             >
                 {label}
+                {rest.required && <RequiredMark />}
             </label>
             <input
                 id={inputId}
                 className={cn(fieldControlClassName, className)}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={hasMessage ? describedById : undefined}
                 {...rest}
+            />
+            <FieldMessages
+                describedById={describedById}
+                error={error}
+                helperText={helperText}
             />
         </div>
     );

--- a/src/components/ui/Spinner/index.tsx
+++ b/src/components/ui/Spinner/index.tsx
@@ -1,21 +1,32 @@
 import { cn } from '@/utils/cn';
 
+type SpinnerProps = React.SVGProps<SVGSVGElement> & {
+    /**
+     * Accessible name for a standalone spinner. When set, the SVG is announced as
+     * a `status` and the label is exposed to screen readers. Omit for decorative
+     * use inside a control whose label already conveys the loading state (e.g. a
+     * Button that swaps to "Sending..."), where the spinner stays `aria-hidden`.
+     */
+    label?: string;
+};
+
 /**
  * Minimal loading spinner. The icon set has no spinner glyph, so this is a small
  * inline SVG: a faint full ring plus a bright arc that rotates via Tailwind's
  * `animate-spin` (motion-safe, so it stays still for reduced-motion users).
  */
-export default function Spinner({
-    className,
-    ...rest
-}: React.SVGProps<SVGSVGElement>) {
+export default function Spinner({ label, className, ...rest }: SpinnerProps) {
+    const accessibility = label
+        ? ({ role: 'status', 'aria-label': label } as const)
+        : ({ 'aria-hidden': true } as const);
+
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"
-            aria-hidden="true"
             className={cn('size-4 motion-safe:animate-spin', className)}
+            {...accessibility}
             {...rest}
         >
             <circle

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,25 +1,36 @@
 import { useId } from 'react';
 import { cn } from '@/utils/cn';
-import { fieldControlClassName } from '@/components/ui/Input';
+import {
+    fieldControlClassName,
+    FieldMessages,
+    RequiredMark,
+} from '@/components/ui/Input';
 
 type TextareaProps = React.ComponentPropsWithRef<'textarea'> & {
     label: string;
     labelClassName?: string;
+    error?: string;
+    helperText?: string;
 };
 
 /**
- * Labeled multiline input. Reuses the shared field styling from Input plus a
- * comfortable min height and vertical resize.
+ * Labeled multiline input. Reuses the shared field styling, required marker, and
+ * error/helper wiring from Input plus a comfortable min height and vertical
+ * resize.
  */
 export default function Textarea({
     label,
     labelClassName,
+    error,
+    helperText,
     id,
     className,
     ...rest
 }: TextareaProps) {
     const generatedId = useId();
     const textareaId = id ?? generatedId;
+    const describedById = `${textareaId}-message`;
+    const hasMessage = Boolean(error || helperText);
 
     return (
         <div className="flex flex-col gap-2 text-left">
@@ -28,11 +39,19 @@ export default function Textarea({
                 className={cn('text-sm font-medium', labelClassName)}
             >
                 {label}
+                {rest.required && <RequiredMark />}
             </label>
             <textarea
                 id={textareaId}
                 className={cn(fieldControlClassName, 'min-h-32 resize-y', className)}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={hasMessage ? describedById : undefined}
                 {...rest}
+            />
+            <FieldMessages
+                describedById={describedById}
+                error={error}
+                helperText={helperText}
             />
         </div>
     );


### PR DESCRIPTION
Accessibility:
- Bump light-mode secondary text from foreground/60 to /70 (was ~4.4:1, now ~6:1)
- Add a skip-link and id="main" on every page's <main>
- Add a Tab focus-trap to useModalChrome; wire it into the Mermaid, Lightbox, and Search modals
- Make viewport.themeColor theme-aware instead of a fixed white
- Fix heading hierarchy: resume name to h1, Projects card titles to h4
- Announce search result count, network-status change, and contact submit error via live regions
- Give Input/Textarea error/helperText props with aria-invalid, aria-describedby, and a required marker

Touch and interaction:
- Raise interactive targets to 44px where space allows, 40/36px for dense toolbars
- Add min-h-11, aria-busy, and touch-manipulation to the shared Button

Consistency and style:
- Add a shared focus-ring utility and apply it across nav/theme chrome, breadcrumb, tag, pager, and pagination links
- Replace the emoji badges on /now and /uses with a Lucide-style SVG icon set, wired through the data model
- Brand the error and not-found pages with the grid backdrop and shared buttons
- Tokenize the grid/dot backgrounds and give the sizeless icons a default size

Typography:
- Cap article prose at ~75ch, add tabular-nums to dates, reserve space for the giscus embed