### PR TITLE
feat(seo): add WebSite and SiteNavigationElement JSON-LD

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,8 @@ import {
 import DeferredGoogleTagManager from '@/components/analytics/DeferredGoogleTagManager';
 import PageviewTracker from '@/components/analytics/PageviewTracker';
 import { JsonLdScript } from '@/components/seo/JsonLdScript';
+import { JsonLd } from '@/components/seo/JsonLd';
+import { websiteJsonLd, siteNavigationJsonLd } from '@/utils/siteJsonLd';
 import { ThemeScript } from '@/components/layout/ThemeToggle/ThemeScript';
 import HashScroll from '@/components/layout/HashScroll';
 import Navbar from '@/components/layout/Navbar';
@@ -130,7 +132,11 @@ export default function RootLayout({
                     content={facebookPageId}
                 ></meta>
                 {process.env.NODE_ENV === 'production' ? (
-                    <JsonLdScript />
+                    <>
+                        <JsonLdScript />
+                        <JsonLd data={websiteJsonLd} />
+                        <JsonLd data={siteNavigationJsonLd} />
+                    </>
                 ) : null}
             </head>
             {process.env.NODE_ENV === 'production' && (

--- a/src/utils/siteJsonLd.ts
+++ b/src/utils/siteJsonLd.ts
@@ -1,0 +1,60 @@
+import { WithContext, WebSite, ItemList } from 'schema-dts';
+
+import {
+    siteURL,
+    siteName,
+    jsonLdAlternateName,
+    jsonLdDescription,
+} from '@/config/constants';
+import {
+    sectionItems,
+    articlesItem,
+    pageItems,
+    resumeItem,
+} from '@/components/layout/Navbar/contents';
+
+/** Join a navbar href (e.g. '/#about', '/uses') onto the absolute site URL. */
+const toAbsoluteUrl = (href: string): string =>
+    `${siteURL}${href.startsWith('/') ? href : `/${href}`}`;
+
+/**
+ * Site-level WebSite entity. Its publisher references the Person emitted (with
+ * the same @id) by the ProfilePage block in @/utils/jsonLd, so both JSON-LD
+ * scripts on the page resolve into one linked entity graph.
+ */
+export const websiteJsonLd: WithContext<WebSite> = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': `${siteURL}#website`,
+    url: siteURL,
+    name: siteName,
+    alternateName: jsonLdAlternateName,
+    description: jsonLdDescription,
+    inLanguage: 'en',
+    publisher: {
+        '@id': `${siteURL}#person`,
+    },
+};
+
+// Primary navigation, reusing the navbar's own definitions as the single source
+// of truth (dev-only studioItems are intentionally excluded).
+const navigationItems = [
+    ...sectionItems,
+    articlesItem,
+    ...pageItems,
+    resumeItem,
+];
+
+/** Declares the primary navigation as SiteNavigationElement candidates. */
+export const siteNavigationJsonLd: WithContext<ItemList> = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    '@id': `${siteURL}#nav`,
+    name: 'Primary navigation',
+    itemListElement: navigationItems.map((item, index) => ({
+        '@type': 'SiteNavigationElement',
+        position: index + 1,
+        name: item.label,
+        url: toAbsoluteUrl(item.href),
+    })),
+};


### PR DESCRIPTION
Emit a site-global WebSite entity (linked to the existing Person via shared @id) and a SiteNavigationElement ItemList built from the navbar's own definitions, both gated to production alongside the ProfilePage block. Gives Google a clearer navigable-entity model to improve sitelinks eligibility.