### PR TITLE
feat(articles): flag series parts in the list with a Part N of M marker

### DIFF
--- a/src/components/icons/layers.tsx
+++ b/src/components/icons/layers.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/utils/cn';
+
+export default function Layers({
+    className,
+    ...rest
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn('size-5', className)}
+            {...rest}
+        >
+            <path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z" />
+            <path d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12" />
+            <path d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17" />
+        </svg>
+    );
+}

--- a/src/components/pages/articles/ArticleCard/SeriesBadge.tsx
+++ b/src/components/pages/articles/ArticleCard/SeriesBadge.tsx
@@ -1,0 +1,48 @@
+import Layers from '@/components/icons/layers';
+import { cn } from '@/utils/cn';
+
+/**
+ * A compact "Part N of M" marker plus the series name, shown at the top of an
+ * ArticleCard when the article belongs to a multi-part series. It reuses the
+ * TechStack chip vocabulary and mirrors the SeriesNav "Part N of M" label so the
+ * list and the article page read as one system. Standalone articles omit it, so
+ * the presence of this marker is what tells a series card apart from a one-off in
+ * the grid. The cover accent shows only through the icon glyph (via --accent-from,
+ * set on the card); the text stays on the foreground token to keep contrast solid
+ * in both themes. `total` is the number of published parts; when it is unknown or
+ * one, the label falls back to "Part N".
+ */
+export default function SeriesBadge({
+    order,
+    total,
+    name,
+    compact = false,
+}: {
+    order: number;
+    total?: number;
+    name: string;
+    compact?: boolean;
+}) {
+    const partLabel =
+        total && total > 1 ? `Part ${order} of ${total}` : `Part ${order}`;
+
+    return (
+        <span
+            className={cn(
+                'flex w-full items-center gap-2',
+                compact ? 'mb-2.5' : 'mb-3'
+            )}
+        >
+            <span className="border-foreground/15 bg-foreground/[0.04] text-foreground/80 inline-flex flex-none items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium tabular-nums">
+                <Layers
+                    aria-hidden
+                    className="size-3.5 text-[var(--accent-from,var(--foreground))]"
+                />
+                {partLabel}
+            </span>
+            <span className="text-foreground/55 min-w-0 truncate text-xs">
+                {name}
+            </span>
+        </span>
+    );
+}

--- a/src/components/pages/articles/ArticleCard/index.tsx
+++ b/src/components/pages/articles/ArticleCard/index.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
 import ArticleCover from '@/components/pages/articles/ArticleCover';
 import styles from '@/components/pages/articles/ArticleCard/ArticleCard.module.css';
+import SeriesBadge from '@/components/pages/articles/ArticleCard/SeriesBadge';
 import TagLink from '@/components/pages/articles/TagLink';
+import { accentStyle } from '@/utils/accentStyle';
 import { cn } from '@/utils/cn';
 import { formatDate } from '@/utils/formatDate';
 import type { ArticleSummary } from '@/lib/posts';
@@ -10,15 +12,21 @@ import type { CSSProperties } from 'react';
 export default function ArticleCard({
     article,
     compact = false,
+    seriesTotal,
 }: {
     article: ArticleSummary;
     compact?: boolean;
+    /** Published part count for this article's series, for the "of M" label. */
+    seriesTotal?: number;
 }) {
     // Tint the card to match its cover thumbnail; the glow itself fades in on
-    // hover (see ArticleCard.module.css).
+    // hover (see ArticleCard.module.css). The same two colours are exposed as the
+    // accent custom properties so the series marker can pick up the card's
+    // identity, matching the rest of the article UI (accentStyle).
     const coverColors = {
         '--cover-from': article.coverColors[0],
         '--cover-to': article.coverColors[1],
+        ...accentStyle(article.coverColors),
     } as CSSProperties;
 
     return (
@@ -45,6 +53,14 @@ export default function ArticleCard({
                     href={`/articles/${article.slug}`}
                     className="flex grow flex-col after:absolute after:inset-0 after:content-['']"
                 >
+                    {article.series && (
+                        <SeriesBadge
+                            order={article.series.order}
+                            total={seriesTotal}
+                            name={article.series.name}
+                            compact={compact}
+                        />
+                    )}
                     <p
                         className={cn(
                             'text-foreground/70 tabular-nums',

--- a/src/components/pages/articles/ArticleGrid.tsx
+++ b/src/components/pages/articles/ArticleGrid.tsx
@@ -1,15 +1,19 @@
 import ArticleCard from '@/components/pages/articles/ArticleCard';
 import { cn } from '@/utils/cn';
+import type { SeriesTotals } from '@/utils/seriesTotals';
 import type { ArticleSummary } from '@/lib/posts';
 
 export default function ArticleGrid({
     articles,
     className,
     compact = false,
+    seriesTotals,
 }: {
     articles: ArticleSummary[];
     className?: string;
     compact?: boolean;
+    /** Series name to published-part count, for each card's "Part N of M" label. */
+    seriesTotals?: SeriesTotals;
 }) {
     return (
         <ul
@@ -23,6 +27,11 @@ export default function ArticleGrid({
                     key={article.slug}
                     article={article}
                     compact={compact}
+                    seriesTotal={
+                        article.series
+                            ? seriesTotals?.[article.series.name]
+                            : undefined
+                    }
                 />
             ))}
         </ul>

--- a/src/components/pages/articles/ArticlesIndex.tsx
+++ b/src/components/pages/articles/ArticlesIndex.tsx
@@ -7,6 +7,7 @@ import ArticlesList from '@/components/pages/articles/ArticlesList';
 import Pagination from '@/components/pages/articles/Pagination';
 import TagFilter from '@/components/pages/articles/TagFilter';
 import { buildPageHref } from '@/utils/pageHref';
+import { buildSeriesTotals } from '@/utils/seriesTotals';
 import { ARTICLES_PER_PAGE, type ArticleSummary } from '@/lib/posts';
 
 export default function ArticlesIndex({
@@ -20,6 +21,7 @@ export default function ArticlesIndex({
         1,
         Math.ceil(articles.length / ARTICLES_PER_PAGE)
     );
+    const seriesTotals = buildSeriesTotals(articles);
 
     return (
         <main
@@ -48,6 +50,7 @@ export default function ArticlesIndex({
                         />
                         <ArticleGrid
                             articles={articles.slice(0, ARTICLES_PER_PAGE)}
+                            seriesTotals={seriesTotals}
                         />
                         <Pagination
                             current={1}

--- a/src/components/pages/articles/ArticlesList.tsx
+++ b/src/components/pages/articles/ArticlesList.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import ArticleGrid from '@/components/pages/articles/ArticleGrid';
 import Pagination from '@/components/pages/articles/Pagination';
 import TagFilter from '@/components/pages/articles/TagFilter';
 import { buildPageHref } from '@/utils/pageHref';
+import { buildSeriesTotals } from '@/utils/seriesTotals';
 import type { ArticleSummary } from '@/lib/posts';
 
 interface ArticlesListProps {
@@ -23,6 +25,10 @@ export default function ArticlesList({
     const filtered = activeTag
         ? articles.filter((article) => article.tags.includes(activeTag))
         : articles;
+
+    // Count parts from the full set, not the filtered/paged slice, so "Part N of
+    // M" stays correct even when a tag filter hides some parts of a series.
+    const seriesTotals = useMemo(() => buildSeriesTotals(articles), [articles]);
 
     const totalPages = Math.max(1, Math.ceil(filtered.length / perPage));
     const requested = Number(searchParams.get('page'));
@@ -50,6 +56,7 @@ export default function ArticlesList({
                 <>
                     <ArticleGrid
                         articles={filtered.slice(start, start + perPage)}
+                        seriesTotals={seriesTotals}
                     />
                     <Pagination
                         current={current}

--- a/src/components/pages/home/ArticlesArea/index.tsx
+++ b/src/components/pages/home/ArticlesArea/index.tsx
@@ -1,11 +1,15 @@
 import Link from 'next/link';
 import ArticleCard from '@/components/pages/articles/ArticleCard';
 import SectionHeading from '@/components/pages/common/SectionHeading';
-import { getLatestArticles } from '@/lib/posts';
+import { buildSeriesTotals } from '@/utils/seriesTotals';
+import { getAllArticles, getLatestArticles } from '@/lib/posts';
 
 export default function ArticlesArea() {
     const latest = getLatestArticles(3);
     if (latest.length === 0) return null;
+
+    // Totals come from the whole corpus so a teased part still reads "of M".
+    const seriesTotals = buildSeriesTotals(getAllArticles());
 
     return (
         <section
@@ -22,6 +26,11 @@ export default function ArticlesArea() {
                         <ArticleCard
                             key={article.slug}
                             article={article}
+                            seriesTotal={
+                                article.series
+                                    ? seriesTotals[article.series.name]
+                                    : undefined
+                            }
                         />
                     ))}
                 </ul>

--- a/src/utils/seriesTotals.ts
+++ b/src/utils/seriesTotals.ts
@@ -1,0 +1,26 @@
+import type { ArticleSummary } from '@/lib/posts';
+
+/** A map of series name to the number of published parts in that series. */
+export type SeriesTotals = Record<string, number>;
+
+/**
+ * Count how many published articles belong to each series, keyed by series name.
+ * `ArticleSummary` carries only a part's own `order`, not the size of its set, so
+ * the total for a "Part N of M" label has to be derived from the full corpus.
+ * Pure and list-driven, so it is safe to call on the server or in a client
+ * component that already holds the article list.
+ */
+export function buildSeriesTotals(
+    articles: readonly Pick<ArticleSummary, 'series'>[]
+): SeriesTotals {
+    const totals: SeriesTotals = {};
+
+    for (const article of articles) {
+        const name = article.series?.name;
+        if (name) {
+            totals[name] = (totals[name] ?? 0) + 1;
+        }
+    }
+
+    return totals;
+}


### PR DESCRIPTION
Series cards now show a compact layers-icon pill (Part N of M) plus the series name at the top of the card, so a multi-part article is distinguishable from a standalone one at a glance. Standalone cards are unchanged. The pill reuses the TechStack chip vocabulary and mirrors the SeriesNav label; the cover accent shows through the icon only, keeping text on the foreground token for contrast in both themes. Per-series totals are derived from the full corpus and threaded to each card for the of-M count.