### PR TITLE
feat(articles): tint code-block hover bloom with the cover accent

### DIFF
--- a/src/components/pages/articles/ArticleContent/ArticleContent.module.css
+++ b/src/components/pages/articles/ArticleContent/ArticleContent.module.css
@@ -82,20 +82,23 @@
     background-color: var(--shiki-light-bg);
 }
 
-/* Signature accent bloom on the code preview window, mirroring the /uses terminal
-   and the ContactForm panel: a soft emerald radial wash that is absent at rest and
-   blooms in only on hover, stepped up a touch in dark mode. Emerald ties the glow
-   to the terminal/code aesthetic. The figure background is opaque (the Shiki
-   palette), so the wash sits on a pointer-safe overlay above the surface, kept low
-   and top-anchored so code legibility is untouched. radial-gradient + color-mix
-   are the sanctioned raw-CSS exceptions; the rest is @apply. */
+/* Signature accent bloom on the code preview window: a soft radial wash that is
+   absent at rest and blooms in only on hover, stepped up a touch in dark mode.
+   Coloured from the article's cover accent (--accent-to, the same colour the
+   active "On this page" marker uses; set on the content root via accentStyle), so
+   the code block matches the page's per-article identity. Where no cover accent is
+   in scope (the editor preview), it falls back to emerald, tying the glow to the
+   terminal/code aesthetic. The figure background is opaque (the Shiki palette), so
+   the wash sits on a pointer-safe overlay above the surface, kept low and
+   top-anchored so code legibility is untouched. radial-gradient + color-mix are
+   the sanctioned raw-CSS exceptions; the rest is @apply. */
 .content :global(.code-block)::before {
     @apply pointer-events-none absolute inset-0 z-10 opacity-0 content-[''] motion-safe:transition-opacity motion-safe:duration-700 motion-safe:ease-out;
     background-image: radial-gradient(
         70% 70% at 50% 0%,
         color-mix(
             in oklab,
-            var(--color-emerald-500) var(--code-glow),
+            var(--accent-to, var(--color-emerald-500)) var(--code-glow),
             transparent
         ),
         transparent 72%

--- a/src/components/pages/articles/ArticleContent/index.tsx
+++ b/src/components/pages/articles/ArticleContent/index.tsx
@@ -1,4 +1,5 @@
 import { jetBrainsMono } from '@/config/monoFont';
+import { accentStyle } from '@/utils/accentStyle';
 import { cn } from '@/utils/cn';
 import styles from '@/components/pages/articles/ArticleContent/ArticleContent.module.css';
 
@@ -6,10 +7,22 @@ import styles from '@/components/pages/articles/ArticleContent/ArticleContent.mo
  * Renders an article's pre-built HTML (Markdown rendered with Shiki code
  * highlighting and inlined gists) as Typography prose. Code-block, inline-code,
  * and gist styling live in the colocated CSS Module.
+ *
+ * The optional cover accent is exposed as --accent-from / --accent-to (via
+ * accentStyle) so the code-block hover bloom can tint to the article's cover
+ * colour, the same colour the active "On this page" marker uses. It is omitted
+ * in the editor preview, where the bloom falls back to emerald.
  */
-export default function ArticleContent({ html }: { html: string }) {
+export default function ArticleContent({
+    html,
+    accentColors,
+}: {
+    html: string;
+    accentColors?: readonly [string, string];
+}) {
     return (
         <div
+            style={accentColors ? accentStyle(accentColors) : undefined}
             className={cn(
                 jetBrainsMono.variable,
                 // Cap the reading measure at ~75ch so body lines stay in the

--- a/src/components/pages/articles/ArticleView/index.tsx
+++ b/src/components/pages/articles/ArticleView/index.tsx
@@ -121,7 +121,10 @@ export default function ArticleView({
                             accentColors={article.coverColors}
                         />
 
-                        <ArticleContent html={article.html} />
+                        <ArticleContent
+                            html={article.html}
+                            accentColors={article.coverColors}
+                        />
 
                         <MermaidRenderer />
                         <CodeBlockCopy />


### PR DESCRIPTION
The Shiki code preview hover glow now uses the article cover accent (--accent-to, the same colour the active "On this page" marker uses) instead of a fixed emerald, so the code block carries the per-article identity. It falls back to emerald in the dev editor preview, which has no cover colours.