### PR TITLE
feat(projects): add Al-Quran Quote skin and collapse the packages grid

### DIFF
--- a/src/app/resume/contents.ts
+++ b/src/app/resume/contents.ts
@@ -332,6 +332,15 @@ export const resumeSections: ResumeSectionData[] = [
                 tech: ['Vue.js', 'JavaScript'],
                 url: 'https://www.npmjs.com/package/advanced-laravel-vue-paginate',
             },
+            {
+                name: 'Al-Quran Quote',
+                tagline: 'Published Rainmeter skin',
+                highlights: [
+                    'Windows desktop skin that displays Al-Quran verses with their reference, offline by default with optional quran.com API fetching.',
+                ],
+                tech: ['Rainmeter', 'Lua'],
+                url: 'https://github.com/shibbirweb/rainmeter-skin-al-quran-quote',
+            },
         ],
     },
     {

--- a/src/components/pages/home/ProjectsArea/MorePackageProjects.tsx
+++ b/src/components/pages/home/ProjectsArea/MorePackageProjects.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Button from '@/components/ui/Button';
+import ChevronIcon from '@/components/icons/chevron';
+import { useDisclosure } from '@/components/layout/Navbar/hooks/useDisclosure';
+import { cn } from '@/utils/cn';
+import type { ReactNode } from 'react';
+
+const revealRegionId = 'more-package-projects';
+
+/**
+ * Holds the tail of the packages grid behind a "Show more" toggle so the
+ * section opens short. The hidden cards stay in the DOM (plain `hidden`, not
+ * unmounted), so they still ship in the static export and stay reachable by
+ * crawlers and in-page find.
+ *
+ * Renders as two siblings with no margins of their own: the parent group's
+ * `space-y-6` spaces them, and a `hidden` child generates no box, so the gap
+ * stays correct in both states.
+ */
+export default function MorePackageProjects({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    const { open, toggle } = useDisclosure();
+
+    return (
+        <>
+            <div
+                id={revealRegionId}
+                hidden={!open}
+            >
+                {children}
+            </div>
+
+            <div className="text-center">
+                <Button
+                    variant="text"
+                    onClick={toggle}
+                    aria-expanded={open}
+                    aria-controls={revealRegionId}
+                >
+                    {open ? 'Show less' : 'Show more'}
+                    <ChevronIcon
+                        aria-hidden="true"
+                        className={cn(
+                            'size-4 transition-transform duration-300',
+                            !open && 'rotate-180'
+                        )}
+                    />
+                </Button>
+            </div>
+        </>
+    );
+}

--- a/src/components/pages/home/ProjectsArea/ProjectGrid.tsx
+++ b/src/components/pages/home/ProjectsArea/ProjectGrid.tsx
@@ -3,9 +3,9 @@ import { Project } from '@/components/pages/home/ProjectsArea/contents';
 
 /**
  * A responsive project card grid. When the last row holds a single card (odd
- * count), that card spans both columns but keeps a single-column width and
- * centers, so it never sits lonely against the left edge. `indexOffset` keeps
- * each card's golden-angle glow hue distinct across multiple grids on the page.
+ * count), it stays in the left column at normal column width so the row reads
+ * as a continuation of the grid. `indexOffset` keeps each card's golden-angle
+ * glow hue distinct across multiple grids on the page.
  */
 export default function ProjectGrid({
     projects,
@@ -15,7 +15,7 @@ export default function ProjectGrid({
     indexOffset?: number;
 }) {
     return (
-        <ul className="grid grid-cols-1 gap-6 md:grid-cols-2 md:[&>li:last-child:nth-child(odd)]:col-span-2 md:[&>li:last-child:nth-child(odd)]:mx-auto md:[&>li:last-child:nth-child(odd)]:w-[calc(50%-0.75rem)]">
+        <ul className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {projects.map((project, index) => (
                 <ProjectCard
                     key={project.repoURL}

--- a/src/components/pages/home/ProjectsArea/contents.ts
+++ b/src/components/pages/home/ProjectsArea/contents.ts
@@ -20,6 +20,12 @@ export type Project = {
     links?: ProjectExternalLink[];
 };
 
+/**
+ * How many package projects stay on screen before the "Show more" toggle.
+ * Bump this when a project should be visible without a click.
+ */
+export const collapsedPackageProjectCount = 4;
+
 // Reusable tools published for others (VS Code Marketplace, npm). These carry
 // `links` to their distribution page alongside the source repo.
 export const packageProjects: Project[] = [
@@ -73,6 +79,28 @@ export const packageProjects: Project[] = [
         ],
     },
     {
+        name: 'Al-Quran Quote',
+        category: 'Rainmeter Skin',
+        description:
+            'A Rainmeter desktop skin for Windows that displays Al-Quran verses with their reference on a customizable panel, working offline from bundled verse data with optional live fetching from the quran.com API.',
+        tech: ['Rainmeter', 'Lua'],
+        repoURL: 'https://github.com/shibbirweb/rainmeter-skin-al-quran-quote',
+        links: [
+            {
+                url: 'https://www.deviantart.com/shibbirweb/art/1360611014',
+                label: 'DeviantArt',
+            },
+            {
+                url: 'https://github.com/shibbirweb/rainmeter-skin-al-quran-quote/releases',
+                label: 'Releases',
+            },
+            {
+                url: 'https://github.com/shibbirweb/rainmeter-skin-al-quran-quote/wiki',
+                label: 'Docs',
+            },
+        ],
+    },
+    {
         name: 'Shibbir CLI',
         category: 'CLI Tool',
         description:
@@ -85,14 +113,6 @@ export const packageProjects: Project[] = [
 // Public repos built for personal use, learning, or practice. Source only, no
 // distribution page.
 export const personalProjects: Project[] = [
-    {
-        name: 'Nginx Load Balancer',
-        category: 'DevOps / Infrastructure',
-        description:
-            'An nginx-based load-balancing setup exploring traffic distribution across multiple upstream application instances.',
-        tech: ['Nginx', 'JavaScript', 'Docker'],
-        repoURL: 'https://github.com/shibbirweb/p-nginx-load-balancer',
-    },
     {
         name: 'Cloudflare DNS & Server Manager',
         category: 'Control Panel',
@@ -108,5 +128,13 @@ export const personalProjects: Project[] = [
             'WordPress',
         ],
         repoURL: 'https://github.com/shibbirweb/dns-manager',
+    },
+    {
+        name: 'Nginx Load Balancer',
+        category: 'DevOps / Infrastructure',
+        description:
+            'An nginx-based load-balancing setup exploring traffic distribution across multiple upstream application instances.',
+        tech: ['Nginx', 'JavaScript', 'Docker'],
+        repoURL: 'https://github.com/shibbirweb/p-nginx-load-balancer',
     },
 ];

--- a/src/components/pages/home/ProjectsArea/index.tsx
+++ b/src/components/pages/home/ProjectsArea/index.tsx
@@ -1,12 +1,22 @@
 import SectionHeading from '@/components/pages/common/SectionHeading';
+import MorePackageProjects from '@/components/pages/home/ProjectsArea/MorePackageProjects';
 import ProjectGrid from '@/components/pages/home/ProjectsArea/ProjectGrid';
 import ResumeBridge from '@/components/pages/home/ProjectsArea/ResumeBridge';
 import {
+    collapsedPackageProjectCount,
     packageProjects,
     personalProjects,
 } from '@/components/pages/home/ProjectsArea/contents';
 
 export default function ProjectsArea() {
+    const visiblePackageProjects = packageProjects.slice(
+        0,
+        collapsedPackageProjectCount
+    );
+    const hiddenPackageProjects = packageProjects.slice(
+        collapsedPackageProjectCount
+    );
+
     return (
         <section
             id="work"
@@ -24,7 +34,15 @@ export default function ProjectsArea() {
                     <h3 className="text-foreground/70 text-center text-sm font-bold tracking-wider uppercase">
                         Packages &amp; Plugins
                     </h3>
-                    <ProjectGrid projects={packageProjects} />
+                    <ProjectGrid projects={visiblePackageProjects} />
+                    {hiddenPackageProjects.length > 0 && (
+                        <MorePackageProjects>
+                            <ProjectGrid
+                                projects={hiddenPackageProjects}
+                                indexOffset={visiblePackageProjects.length}
+                            />
+                        </MorePackageProjects>
+                    )}
                 </div>
 
                 <div className="mt-12 space-y-6">

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/utils/cn';
 import Spinner from '@/components/ui/Spinner';
 
-export type ButtonVariant = 'primary' | 'outline';
+export type ButtonVariant = 'primary' | 'outline' | 'text';
 
 const buttonBaseClassName =
     'focus-ring inline-flex min-h-11 cursor-pointer touch-manipulation items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors';
@@ -11,6 +11,10 @@ const variantClassNames: Record<ButtonVariant, string> = {
         'bg-foreground text-background hover:bg-foreground/85 disabled:cursor-not-allowed disabled:opacity-60',
     outline:
         'border-foreground/15 border hover:bg-foreground/5 disabled:cursor-not-allowed disabled:opacity-60',
+    // Reads as an underlined text link while staying a real button. For quiet,
+    // in-flow actions (a "Show more" reveal) that should not compete with the
+    // filled and outlined actions around them.
+    text: 'text-foreground/70 decoration-foreground/30 hover:text-foreground hover:decoration-foreground underline underline-offset-4 disabled:cursor-not-allowed disabled:opacity-60',
 };
 
 /**


### PR DESCRIPTION
Add the Al-Quran Quote Rainmeter skin to the home Projects section and to the resume Open Source list, linking its DeviantArt listing, GitHub releases, and wiki docs.

Packages & Plugins now shows four cards and holds the rest behind a "Show more" toggle, built on a new text variant of the shared Button so the control reads as a link. A lone last card sits left-aligned instead of centered, and the personal projects lead with the Cloudflare DNS manager.