### PR TITLE
perf(contact): defer hCaptcha until the reader engages with the form

### DIFF
--- a/src/components/pages/home/ContactArea/CaptchaSlot.module.css
+++ b/src/components/pages/home/ContactArea/CaptchaSlot.module.css
@@ -1,0 +1,47 @@
+@reference "tailwindcss";
+
+/* Placeholder styling for the captcha slot, scoped to the component. Everything
+   expressible as a utility uses @apply; only the sweep gradient and its @keyframes
+   body are raw CSS, since Tailwind cannot express either. */
+
+/* The shimmer rides ::after so the placeholder's own text stays untouched by it.
+   It is transparent until the script is actually in flight, so the slot sits calm
+   at rest and the sweep only ever means "fetching". */
+.placeholder::after {
+    @apply pointer-events-none absolute inset-0 rounded-[inherit] opacity-0 content-[''] motion-safe:transition-opacity motion-safe:duration-300;
+    background-image: linear-gradient(
+        100deg,
+        transparent 25%,
+        color-mix(in oklab, var(--foreground) var(--shimmer-strength), transparent)
+            50%,
+        transparent 75%
+    );
+    background-size: 200% 100%;
+}
+
+.placeholder {
+    /* Light rests lower, matching the glow tokens on the other surfaces. */
+    --shimmer-strength: 9%;
+}
+
+@media (prefers-color-scheme: dark) {
+    :global(html:not([data-theme])) .placeholder {
+        --shimmer-strength: 16%;
+    }
+}
+:global(html[data-theme='dark']) .placeholder {
+    --shimmer-strength: 16%;
+}
+
+.loading::after {
+    @apply opacity-100 motion-safe:animate-[captcha-shimmer_1.5s_linear_infinite];
+}
+
+@keyframes captcha-shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}

--- a/src/components/pages/home/ContactArea/CaptchaSlot.tsx
+++ b/src/components/pages/home/ContactArea/CaptchaSlot.tsx
@@ -1,0 +1,65 @@
+import { cn } from '@/utils/cn';
+import styles from '@/components/pages/home/ContactArea/CaptchaSlot.module.css';
+import { captchaPlaceholderLabel } from '@/components/pages/home/ContactArea/contents';
+
+type CaptchaSlotProps = {
+    /** The callback ref from `useHCaptcha`, attached to the widget's container. */
+    setContainer: (node: HTMLDivElement | null) => void;
+    isWidgetRendered: boolean;
+    /** The vendor script is in flight, so the placeholder should read as busy. */
+    isLoading: boolean;
+    /** Opens the captcha gate. Pointing at the slot is intent enough to start. */
+    onIntent: () => void;
+};
+
+/**
+ * Holds the widget's space in the form and stands in for it until it arrives.
+ *
+ * hCaptcha renders a fixed 302x76 widget. Below ~368px that cannot fit the panel,
+ * so it is scaled down from the left inside an overflow-hidden wrapper (which also
+ * caps the layout width so nothing spills past the rounded panel). `scale()` only
+ * affects paint, never layout, so the wrapper's content box is 76px tall at every
+ * width and one unconditional `min-h` reserves it correctly everywhere.
+ *
+ * That reservation is what keeps the deferred load free: without it the widget
+ * would drop in under the reader's eyes and shove the submit button down.
+ *
+ * The placeholder says what belongs here and nothing more. It deliberately does not
+ * mock up the widget's checkbox: a checkbox that cannot be ticked is a lie about
+ * what the reader is looking at, and they would click it before the real one exists.
+ *
+ * Pointing at the slot opens the gate, so the script is usually already on its way
+ * before the reader reaches for a field, and the shimmer that runs while it loads
+ * is reporting real work rather than decorating a wait.
+ */
+export default function CaptchaSlot({
+    setContainer,
+    isWidgetRendered,
+    isLoading,
+    onIntent,
+}: CaptchaSlotProps) {
+    return (
+        <div
+            className="relative min-h-[76px] w-full overflow-hidden"
+            onPointerEnter={onIntent}
+        >
+            {!isWidgetRendered && (
+                // Absolutely positioned, so removing it cannot reflow anything.
+                <div
+                    aria-hidden="true"
+                    className={cn(
+                        styles.placeholder,
+                        'border-foreground/15 bg-foreground/5 text-foreground/55 pointer-events-none absolute top-0 left-0 flex h-[76px] w-[302px] origin-top-left items-center justify-center overflow-hidden rounded-md border text-sm max-[368px]:scale-[0.8]',
+                        isLoading && styles.loading
+                    )}
+                >
+                    {captchaPlaceholderLabel}
+                </div>
+            )}
+            <div
+                ref={setContainer}
+                className="flex origin-top-left justify-start max-[368px]:scale-[0.8]"
+            />
+        </div>
+    );
+}

--- a/src/components/pages/home/ContactArea/ContactForm.tsx
+++ b/src/components/pages/home/ContactArea/ContactForm.tsx
@@ -8,10 +8,13 @@ import Textarea from '@/components/ui/Textarea';
 import SpotlightBorder from '@/components/pages/common/SpotlightBorder';
 import { useSpotlightSurfaces } from '@/components/pages/common/hooks/useSpotlightSurfaces';
 import { spotlightSurfaceProps } from '@/components/pages/common/spotlightSurface';
+import CaptchaSlot from '@/components/pages/home/ContactArea/CaptchaSlot';
 import ContactAside from '@/components/pages/home/ContactArea/ContactAside';
 import ContactSuccess from '@/components/pages/home/ContactArea/ContactSuccess';
 import styles from '@/components/pages/home/ContactArea/ContactForm.module.css';
+import { captchaHint } from '@/components/pages/home/ContactArea/captchaHint';
 import { useContactForm } from '@/components/pages/home/ContactArea/hooks/useContactForm';
+import { useFirstInteraction } from '@/components/pages/home/ContactArea/hooks/useFirstInteraction';
 import { useHCaptcha } from '@/components/pages/home/ContactArea/hooks/useHCaptcha';
 import {
     contactFields,
@@ -26,17 +29,33 @@ const fieldLabelClassName =
     'text-foreground/70 text-xs font-semibold tracking-[0.14em] uppercase';
 
 export default function ContactForm() {
-    const { setContainer, token, reset: resetCaptcha } = useHCaptcha();
-    const { values, status, errorMessage, updateField, handleSubmit, reset } =
-        useContactForm({ captchaToken: token, resetCaptcha });
-
-    const isSubmitting = status === 'submitting';
-
     // The panel is its own spotlight group: one delegated pointer listener here
     // writes --pointer-x/y to the panel, which the cursor glow and the lit border in
     // ContactForm.module.css both read.
     const panelRef = useRef<HTMLDivElement>(null);
     useSpotlightSurfaces(panelRef);
+
+    // hCaptcha is third-party JS for a control at the very bottom of the page, so
+    // it is fetched when the reader actually engages with the form rather than at
+    // hydration. Most visitors read and leave, and they should not pay for it.
+    const { hasInteracted, interactionProps, markInteracted } =
+        useFirstInteraction();
+
+    const {
+        setContainer,
+        token,
+        reset: resetCaptcha,
+        isWidgetRendered,
+    } = useHCaptcha({ shouldLoad: hasInteracted });
+    const { values, status, errorMessage, updateField, handleSubmit, reset } =
+        useContactForm({ captchaToken: token, resetCaptcha });
+
+    const isSubmitting = status === 'submitting';
+    const hintMessage = captchaHint({
+        hasToken: Boolean(token),
+        hasInteracted,
+        isWidgetRendered,
+    });
 
     return (
         <div className="w-full max-w-4xl">
@@ -61,6 +80,10 @@ export default function ContactForm() {
                         ) : (
                             <form
                                 onSubmit={handleSubmit}
+                                // Opens the captcha gate: every field and the
+                                // captcha slot itself sit inside this form, so any
+                                // click or tab into it counts as engagement.
+                                {...interactionProps}
                                 className="flex flex-col gap-5"
                             >
                                 {contactFields.map((field) => (
@@ -98,17 +121,14 @@ export default function ContactForm() {
                                     }
                                 />
 
-                                {/* hCaptcha renders a fixed 302px widget. Below
-                                    ~368px that cannot fit the panel, so scale it
-                                    down from the left inside an overflow-hidden
-                                    wrapper (the wrapper caps the layout width so
-                                    nothing spills past the rounded panel). */}
-                                <div className="w-full overflow-hidden">
-                                    <div
-                                        ref={setContainer}
-                                        className="flex origin-top-left justify-start max-[368px]:scale-[0.8]"
-                                    />
-                                </div>
+                                <CaptchaSlot
+                                    setContainer={setContainer}
+                                    isWidgetRendered={isWidgetRendered}
+                                    isLoading={
+                                        hasInteracted && !isWidgetRendered
+                                    }
+                                    onIntent={markInteracted}
+                                />
 
                                 {status === 'error' && errorMessage && (
                                     <p
@@ -144,10 +164,9 @@ export default function ContactForm() {
                                             </svg>
                                         )}
                                     </Button>
-                                    {!token && (
+                                    {hintMessage && (
                                         <span className="text-foreground/70 text-xs">
-                                            Complete the captcha to enable
-                                            sending.
+                                            {hintMessage}
                                         </span>
                                     )}
                                 </div>

--- a/src/components/pages/home/ContactArea/captchaHint.ts
+++ b/src/components/pages/home/ContactArea/captchaHint.ts
@@ -1,0 +1,36 @@
+import {
+    captchaLoadingHint,
+    captchaUnsolvedHint,
+} from '@/components/pages/home/ContactArea/contents';
+
+type CaptchaHintArgs = {
+    hasToken: boolean;
+    hasInteracted: boolean;
+    isWidgetRendered: boolean;
+};
+
+/**
+ * The line under the submit button explaining why it is disabled, or null once it
+ * is not. Four states, so this is a helper with early returns rather than a stack
+ * of ternaries in the JSX.
+ *
+ * The untouched form falls through to the unsolved hint rather than the loading
+ * one: nothing is downloading yet, and the reason the button is disabled really is
+ * that the captcha is not done.
+ */
+export function captchaHint({
+    hasToken,
+    hasInteracted,
+    isWidgetRendered,
+}: CaptchaHintArgs): string | null {
+    if (hasToken) {
+        return null;
+    }
+    if (isWidgetRendered) {
+        return captchaUnsolvedHint;
+    }
+    if (hasInteracted) {
+        return captchaLoadingHint;
+    }
+    return captchaUnsolvedHint;
+}

--- a/src/components/pages/home/ContactArea/contents.ts
+++ b/src/components/pages/home/ContactArea/contents.ts
@@ -47,6 +47,13 @@ export const messageField = {
 export const submitLabel = 'Send message';
 export const submittingLabel = 'Sending...';
 
+// Stands in for the widget before it loads. Names what belongs there without
+// imitating any part of the control itself.
+export const captchaPlaceholderLabel = 'Solve the captcha';
+
+export const captchaLoadingHint = 'Loading the captcha...';
+export const captchaUnsolvedHint = 'Complete the captcha to enable sending.';
+
 export const successTitle = 'Message sent successfully';
 export const successSubtitle =
     'Thanks for reaching out. I will get back to you soon. Need to add something?';

--- a/src/components/pages/home/ContactArea/hooks/useFirstInteraction.ts
+++ b/src/components/pages/home/ContactArea/hooks/useFirstInteraction.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Latches true the first time the reader focuses or points at the subtree the
+ * returned props are spread onto, and never goes back. `onFocusCapture` covers a
+ * keyboard visitor tabbing in; `onPointerDownCapture` covers a click or tap
+ * anywhere inside, including areas that are not focusable. Both use the capture
+ * phase so a child stopping propagation cannot hide the interaction.
+ *
+ * `markInteracted` is returned as well so a caller can add narrower signals of its
+ * own (hovering one particular control, say) without widening the whole subtree.
+ *
+ * Used to hold an expensive third-party dependency back until the reader shows
+ * they actually want the thing it powers, so the latch must be one-way: once the
+ * work has started, letting it flip back would tear down whatever it produced.
+ */
+export function useFirstInteraction() {
+    const [hasInteracted, setHasInteracted] = useState(false);
+
+    const markInteracted = useCallback(() => setHasInteracted(true), []);
+
+    // Every later interaction fires these too, but setting the same value is a
+    // no-op bail in React, so no extra guard is needed.
+    const interactionProps = useMemo(
+        () => ({
+            onFocusCapture: markInteracted,
+            onPointerDownCapture: markInteracted,
+        }),
+        [markInteracted]
+    );
+
+    return { hasInteracted, interactionProps, markInteracted };
+}

--- a/src/components/pages/home/ContactArea/hooks/useHCaptcha.ts
+++ b/src/components/pages/home/ContactArea/hooks/useHCaptcha.ts
@@ -7,6 +7,15 @@ const HCAPTCHA_SCRIPT_SRC = 'https://js.hcaptcha.com/1/api.js?render=explicit';
 
 let scriptPromise: Promise<void> | null = null;
 
+type UseHCaptchaArgs = {
+    /**
+     * Opens the gate on the vendor script. The caller owns the latch and is
+     * responsible for keeping it one-way: flipping it back would strand a
+     * rendered widget with no way to reach it.
+     */
+    shouldLoad: boolean;
+};
+
 /**
  * Loads the hCaptcha API script exactly once (guarded by a module-level
  * promise) and resolves when `window.hcaptcha` is ready. SSR-safe: it only
@@ -45,26 +54,43 @@ function loadHCaptchaScript(): Promise<void> {
  * node on mount and null on unmount, so the widget is created and torn down in
  * step with the container (keeping the success/resend remount correct).
  *
+ * The vendor script is not fetched until `shouldLoad` opens. The container
+ * mounts with the rest of the form, long before anyone wants a captcha, and this
+ * is third-party JS nobody who only reads the page should have to download, so
+ * the caller decides when it is worth the bytes. Deferring past the first commit
+ * also means `useResolvedTheme` has already corrected itself, so a dark-mode
+ * visitor no longer gets a light widget rendered and immediately replaced.
+ *
  * The widget's theme is baked in at render time, so it also tracks the site
  * theme: when the user switches light/dark the widget is removed and re-rendered
  * with the new theme so it always matches the surrounding UI. Read `token` to
  * know the challenge is solved; call `reset()` to clear a solved (single-use)
- * token.
+ * token. `isWidgetRendered` says whether the widget is on screen yet, so the
+ * caller can hold a placeholder in its place.
  */
-export function useHCaptcha() {
+export function useHCaptcha({ shouldLoad }: UseHCaptchaArgs) {
     const widgetIdRef = useRef<string | null>(null);
     const nodeRef = useRef<HTMLDivElement | null>(null);
     const renderedThemeRef = useRef<ResolvedTheme | null>(null);
     const [token, setToken] = useState<string | null>(null);
+    const [isWidgetRendered, setIsWidgetRendered] = useState(false);
 
     const theme = useResolvedTheme();
     // Read the latest theme from inside async callbacks without re-creating them.
     const themeRef = useRef<ResolvedTheme>(theme);
     themeRef.current = theme;
 
+    // Same idiom as themeRef, and here it is load bearing: reading the gate from
+    // a ref keeps renderWidget and removeWidget out of any dependency array, so
+    // setContainer holds one identity for the life of the component. Were that
+    // identity to change, React would call the old callback ref with null (tearing
+    // the widget down and dropping a solved token) before calling the new one.
+    const shouldLoadRef = useRef(shouldLoad);
+    shouldLoadRef.current = shouldLoad;
+
     const renderWidget = useCallback(() => {
         const node = nodeRef.current;
-        if (!node) {
+        if (!node || !shouldLoadRef.current) {
             return;
         }
         loadHCaptchaScript()
@@ -85,6 +111,7 @@ export function useHCaptcha() {
                     'error-callback': () => setToken(null),
                 });
                 renderedThemeRef.current = activeTheme;
+                setIsWidgetRendered(true);
             })
             .catch(() => {
                 // Token stays null, so the submit button stays disabled and the
@@ -99,6 +126,7 @@ export function useHCaptcha() {
         widgetIdRef.current = null;
         renderedThemeRef.current = null;
         setToken(null);
+        setIsWidgetRendered(false);
     }, []);
 
     const setContainer = useCallback(
@@ -112,6 +140,17 @@ export function useHCaptcha() {
         },
         [renderWidget, removeWidget]
     );
+
+    // The container mounts long before the widget is wanted, so the ref callback's
+    // renderWidget call bails on the closed gate. This is the other way in: the
+    // moment the caller opens it. renderWidget is []-stable, so this only runs on a
+    // real flip, and if the gate is already open when the container mounts the
+    // widgetIdRef check inside renderWidget makes the duplicate call a no-op.
+    useEffect(() => {
+        if (shouldLoad) {
+            renderWidget();
+        }
+    }, [shouldLoad, renderWidget]);
 
     // Re-render with the new theme whenever it changes and a widget is mounted.
     useEffect(() => {
@@ -131,5 +170,5 @@ export function useHCaptcha() {
         }
     }, []);
 
-    return { setContainer, token, reset };
+    return { setContainer, token, reset, isWidgetRendered };
 }


### PR DESCRIPTION
useHCaptcha injected js.hcaptcha.com/api.js from renderWidget, which the setContainer callback ref fires the moment the container div mounts. That container mounts with the rest of the home page, so the vendor script was fetched at hydration for every visitor, whether or not they ever scrolled to the contact panel or wrote a message, and it was showing up as third-party cost in PageSpeed runs.

The script is now gated on the reader's first interaction with the form: focus or pointer-down anywhere inside it, or the pointer merely entering the captcha slot. Lighthouse neither scrolls nor interacts, so an audit run no longer fetches hCaptcha at all.

Alongside that:

* useFirstInteraction is the latch, and it is deliberately one way. Letting it flip back would tear down a widget whose challenge is already solved.
* useHCaptcha reads the gate from a ref rather than a dependency, so setContainer keeps one identity for the life of the component. Were that identity to change, React would call the old callback ref with null, running removeWidget and dropping a solved token, before calling the new one.
* CaptchaSlot reserves the widget's 302x76 box in the prerendered HTML. Without it the deferred widget would drop in under the reader's eyes and shove the submit button down, trading a load-time cost for a layout-shift one.
* The placeholder names what belongs there and nothing else. It does not mock up the checkbox, since one that cannot be ticked misrepresents what the reader is looking at. Pointing at the slot starts the fetch, so the shimmer running over it reports real work rather than decorating a wait.
* The captcha hint copy moves into contents.ts, where the rest of the section's strings already live, and gains a loading state through a captchaHint helper with early returns.

Deferring past the first commit also means useResolvedTheme has settled by the time the widget renders, so a dark mode visitor no longer gets a light widget built and immediately replaced.

Verified in headless Chromium against the built export, light and dark: no hcaptcha request on load or after scrolling to #contact, api.js firing on hover or focus alone, the slot measuring 76px before and after the widget at both normal and sub-368px widths, the widget node surviving re-renders, and a theme switch still re-rendering exactly one widget.