### PR TITLE
fix(nav): track the home articles teaser as its own section anchor

### DIFF
--- a/src/components/layout/Navbar/contents.ts
+++ b/src/components/layout/Navbar/contents.ts
@@ -38,7 +38,18 @@ export const studioItems: NavItemData[] = [
     { label: 'Article Editor', href: '/studio/article-editor' },
 ];
 
-export const sectionIds = sectionItems.map((item) => item.sectionId as string);
+// Home page section anchors tracked by the scroll spy, in document order (see
+// src/app/page.tsx). A superset of the sectionItems above: the Articles teaser
+// owns the URL hash while it is in view, but it is not a navbar entry (the
+// navbar's Articles link points at the /articles page). Every sectionId in
+// sectionItems must appear here.
+export const homeSectionIds = [
+    'about',
+    'skills',
+    'work',
+    'articles',
+    'contact',
+];
 
 // id of the hero element on the home page; observed to toggle the navbar.
 export const heroId = 'hero';

--- a/src/components/layout/Navbar/index.tsx
+++ b/src/components/layout/Navbar/index.tsx
@@ -8,9 +8,9 @@ import ThemeMenu from '@/components/layout/ThemeToggle/ThemeMenu';
 import {
     articlesItem,
     heroId,
+    homeSectionIds,
     pageItems,
     resumeItem,
-    sectionIds,
     sectionItems,
     studioItems,
     type NavItemData,
@@ -26,7 +26,7 @@ export default function Navbar({
     const pathname = usePathname();
     const isHome = pathname === '/';
     const brandVisible = useHeroPassed(isHome, heroId);
-    const activeSection = useScrollSpy(sectionIds, isHome);
+    const activeSection = useScrollSpy(homeSectionIds, isHome);
     // The resume page always exists, so its nav item is always shown.
     const pages = [
         ...(hasArticles ? [articlesItem] : []),

--- a/src/components/layout/SectionUrlSync/index.tsx
+++ b/src/components/layout/SectionUrlSync/index.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { heroId, sectionIds } from '@/components/layout/Navbar/contents';
+import { heroId, homeSectionIds } from '@/components/layout/Navbar/contents';
 import { useScrollSpy } from '@/components/layout/Navbar/hooks/useScrollSpy';
 import { useSectionUrlSync } from '@/components/layout/SectionUrlSync/hooks/useSectionUrlSync';
 
 // Stable reference (the spy re-subscribes whenever this array identity changes),
-// the hero plus every section anchor, in document order.
-const spyIds = [heroId, ...sectionIds];
+// the hero plus every home section anchor, in document order.
+const spyIds = [heroId, ...homeSectionIds];
 
 /**
  * Home page only: keeps the URL hash pointing at the section in view as the
- * visitor scrolls (#about, #work, ...), clearing it back to "/" at the hero.
- * Renders nothing.
+ * visitor scrolls (#about, #work, #articles, ...), clearing it back to "/" at
+ * the hero. Tracks every section anchor, including the ones with no navbar
+ * entry. Renders nothing.
  */
 export default function SectionUrlSync() {
     const activeId = useScrollSpy(spyIds);


### PR DESCRIPTION
The scroll spy derived its id list from the navbar menu items, and the Latest Articles teaser is deliberately not a menu item (the navbar's Articles link points at the /articles page). So 'articles' never reached useScrollSpy, which keeps the last section past the 30% line: scrolling into the teaser left 'work' selected, holding the URL at /#work and the Projects pill lit for the whole section, as if the teaser belonged to Projects. The id="articles" anchor was reachable only by pasting the URL.

Replace the derived sectionIds with an explicit, document-ordered homeSectionIds that includes 'articles' between 'work' and 'contact', and read it from both the navbar spy and SectionUrlSync. No sectionItems entry matches 'articles', so the teaser now owns the hash while no pill is lit, keeping the navbar and the address bar in agreement.

sectionItems is untouched, so no menu item is added and the JSON-LD navigation still lists only the four section anchors plus /articles. No hasArticles gating is needed: ArticlesArea returns null on an empty corpus and the spy already filters ids whose element is missing.