### PR TITLE
refactor(uses): present the audio speakers like the keyboards and mouse

### DIFF
--- a/src/app/uses/contents.ts
+++ b/src/app/uses/contents.ts
@@ -107,11 +107,21 @@ export const usesSections: UsesSectionData[] = [
     {
         title: 'Audio',
         Icon: Speaker,
-        intro: 'Perfect for music while coding, online meetings, and watching technical talks.',
         blocks: [
             {
-                kind: 'tags',
-                tags: ['Edifier R1280DBs', 'Edifier T5 Subwoofer'],
+                kind: 'gear',
+                gear: [
+                    {
+                        name: 'Edifier R1280DBs',
+                        description:
+                            'My desktop speakers for online meetings and technical talks. Clear at low volume, with Bluetooth and optical inputs for easy switching between devices.',
+                    },
+                    {
+                        name: 'Edifier T5 Subwoofer',
+                        description:
+                            'Adds the low end the speakers cannot reach, so everything sounds full without turning the volume up.',
+                    },
+                ],
             },
         ],
     },


### PR DESCRIPTION
The Audio section rendered as bare pill tags with a one-line intro, so it read as an inventory list next to the Keyboards and Mouse cards, which give each item a name and a short note on why it earns a spot.

Switch its block from kind 'tags' to kind 'gear' so it renders through GearList like its neighbours, and fold the intro into per-item descriptions. Data-only change: no component, type, or CSS edits, and TagGroup is untouched, so /now and the remaining tag-based sections are unaffected.